### PR TITLE
Fix leftover temp file from SQLite URI tests

### DIFF
--- a/src/llm_accounting/backends/sqlite_backend_parts/connection_manager.py
+++ b/src/llm_accounting/backends/sqlite_backend_parts/connection_manager.py
@@ -30,6 +30,8 @@ class SQLiteConnectionManager:
             db_connection_str = "sqlite:///:memory:"
         elif str(actual_db_path).startswith("file:"):
             db_connection_str = f"sqlite:///{actual_db_path}"
+            if "uri=true" not in actual_db_path:
+                db_connection_str += ("&" if "?" in actual_db_path else "?") + "uri=true"
         else:
             db_connection_str = f"sqlite:///{actual_db_path}"
 


### PR DESCRIPTION
## Summary
- ensure SQLite URI paths use `uri=true`
- remove accidental `file` artifact from repo
- avoid creating temporary db files during tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841501cfb9483339071b5e2f6c92174