### PR TITLE
Implement wildcard limits and add indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ llm-accounting select --query "SELECT model, COUNT(*) as count FROM accounting_e
 
 The `llm-accounting limits` command allows you to manage usage limits for your LLM interactions. It now supports advanced multi-dimensional limiting and rolling time windows. You can set, list, and delete limits based on various scopes (global, model, user, caller, project) and types (requests, input tokens, output tokens, total tokens, cost) over specified time intervals.
 
+Wildcards can be specified using `*` for any of the model, username, caller name, or project name fields. A `max-value` of `0` denies all matching usage, while `-1` allows unlimited usage.
+
 #### Set a Usage Limit
 
 Set a new usage limit. For example, to set a global limit of 1000 requests per day:

--- a/alembic/versions/cc98ec5bdfa4_add_usage_limits_indices.py
+++ b/alembic/versions/cc98ec5bdfa4_add_usage_limits_indices.py
@@ -1,0 +1,29 @@
+"""add indices to usage_limits columns
+
+Revision ID: cc98ec5bdfa4
+Revises: ba9718840e75
+Create Date: 2025-06-08 20:21:20.000000
+
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'cc98ec5bdfa4'
+down_revision: Union[str, None] = 'ba9718840e75'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('usage_limits', schema=None) as batch_op:
+        batch_op.create_index('ix_usage_limits_model', ['model'], unique=False)
+        batch_op.create_index('ix_usage_limits_username', ['username'], unique=False)
+        batch_op.create_index('ix_usage_limits_caller_name', ['caller_name'], unique=False)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('usage_limits', schema=None) as batch_op:
+        batch_op.drop_index('ix_usage_limits_caller_name')
+        batch_op.drop_index('ix_usage_limits_username')
+        batch_op.drop_index('ix_usage_limits_model')

--- a/src/llm_accounting/cli/main.py
+++ b/src/llm_accounting/cli/main.py
@@ -40,7 +40,10 @@ def main():
     _check_privileged_user()
     package_version = get_version('llm-accounting')
     parser = argparse.ArgumentParser(
-        description="LLM Accounting CLI - Track and analyze LLM usage",
+        description=(
+            "LLM Accounting CLI - Track and analyze LLM usage. "
+            "Limits support '*' wildcards and max values of 0 (deny) or -1 (unlimited)."
+        ),
         formatter_class=argparse.RawTextHelpFormatter,
     )
     parser.add_argument('--version', action='version', version=f'llm-accounting {package_version}')

--- a/src/llm_accounting/cli/parsers.py
+++ b/src/llm_accounting/cli/parsers.py
@@ -154,7 +154,10 @@ def add_limits_parser(subparsers):
         help="Type of the limit (requests, input_tokens, output_tokens, total_tokens, cost)",
     )
     set_parser.add_argument(
-        "--max-value", type=float, required=True, help="Maximum value for the limit"
+        "--max-value",
+        type=float,
+        required=True,
+        help="Maximum value for the limit. Use 0 to deny usage, -1 for unlimited",
     )
     set_parser.add_argument(
         "--interval-unit",
@@ -170,18 +173,24 @@ def add_limits_parser(subparsers):
         help="Value of the time interval (e.g., 1 for '1 day')",
     )
     set_parser.add_argument(
-        "--model", type=str, help="Model name for MODEL scope limits. Can be combined with PROJECT scope."
+        "--model",
+        type=str,
+        help="Model name for MODEL scope limits (use '*' as wildcard). Can be combined with PROJECT scope.",
     )
     set_parser.add_argument(
-        "--username", type=str, help="Username for USER scope limits. Can be combined with PROJECT scope."
+        "--username",
+        type=str,
+        help="Username for USER scope limits (use '*' as wildcard). Can be combined with PROJECT scope.",
     )
     set_parser.add_argument(
-        "--caller-name", type=str, help="Caller name for CALLER scope limits. Can be combined with PROJECT scope."
+        "--caller-name",
+        type=str,
+        help="Caller name for CALLER scope limits (use '*' as wildcard). Can be combined with PROJECT scope.",
     )
     set_parser.add_argument(
-        "--project-name", # New argument for project-specific limits
-        type=str, 
-        help="The project name for a PROJECT-specific limit. Required if scope is PROJECT."
+        "--project-name",
+        type=str,
+        help="The project name for a PROJECT-specific limit (use '*' as wildcard). Required if scope is PROJECT.",
     )
     set_parser.set_defaults(func=set_limit)
 

--- a/src/llm_accounting/models/limits.py
+++ b/src/llm_accounting/models/limits.py
@@ -124,8 +124,11 @@ class UsageLimit(Base):
         return delta_map[unit]
 
 # Event listener to create the index with IF NOT EXISTS for SQLite
-event.listen(
-    UsageLimit.__table__,
-    'after_create',
-    DDL("CREATE INDEX IF NOT EXISTS ix_usage_limits_project_name ON usage_limits (project_name)").execute_if(dialect='sqlite')
-)
+for _idx_col in ["project_name", "model", "username", "caller_name"]:
+    event.listen(
+        UsageLimit.__table__,
+        "after_create",
+        DDL(
+            f"CREATE INDEX IF NOT EXISTS ix_usage_limits_{_idx_col} ON usage_limits ({_idx_col})"
+        ).execute_if(dialect="sqlite"),
+    )

--- a/tests/accounting/test_wildcard_limits.py
+++ b/tests/accounting/test_wildcard_limits.py
@@ -1,0 +1,66 @@
+import pytest
+from datetime import datetime, timezone
+from freezegun import freeze_time
+
+from llm_accounting import LLMAccounting
+from llm_accounting.backends.sqlite import SQLiteBackend
+from llm_accounting.models.limits import UsageLimitDTO, LimitScope, LimitType, TimeInterval
+
+@pytest.fixture
+def sqlite_backend_for_accounting(temp_db_path):
+    backend = SQLiteBackend(db_path=temp_db_path)
+    backend.initialize()
+    yield backend
+    backend.close()
+
+@pytest.fixture
+def accounting_instance(sqlite_backend_for_accounting: SQLiteBackend) -> LLMAccounting:
+    acc = LLMAccounting(backend=sqlite_backend_for_accounting)
+    acc.__enter__()
+    yield acc
+    acc.__exit__(None, None, None)
+
+@freeze_time("2024-01-01 00:00:00", tz_offset=0)
+def test_wildcard_deny_and_specific_allow(accounting_instance: LLMAccounting, sqlite_backend_for_accounting: SQLiteBackend):
+    deny_all = UsageLimitDTO(
+        scope=LimitScope.MODEL.value,
+        model="*",
+        limit_type=LimitType.REQUESTS.value,
+        max_value=0,
+        interval_unit=TimeInterval.DAY.value,
+        interval_value=1,
+    )
+    allow_gpt4 = UsageLimitDTO(
+        scope=LimitScope.MODEL.value,
+        model="gpt-4",
+        limit_type=LimitType.REQUESTS.value,
+        max_value=-1,
+        interval_unit=TimeInterval.DAY.value,
+        interval_value=1,
+    )
+    sqlite_backend_for_accounting.insert_usage_limit(deny_all)
+    sqlite_backend_for_accounting.insert_usage_limit(allow_gpt4)
+    accounting_instance.quota_service.refresh_limits_cache()
+
+    allowed, _ = accounting_instance.check_quota("gpt-4", None, "app", 1, 0)
+    assert allowed
+
+    allowed, _ = accounting_instance.check_quota("gpt-3", None, "app", 1, 0)
+    assert not allowed
+
+@freeze_time("2024-01-01 00:00:00", tz_offset=0)
+def test_unlimited_limit(accounting_instance: LLMAccounting, sqlite_backend_for_accounting: SQLiteBackend):
+    unlimited = UsageLimitDTO(
+        scope=LimitScope.USER.value,
+        username="user1",
+        limit_type=LimitType.COST.value,
+        max_value=-1,
+        interval_unit=TimeInterval.DAY.value,
+        interval_value=1,
+    )
+    sqlite_backend_for_accounting.insert_usage_limit(unlimited)
+    accounting_instance.quota_service.refresh_limits_cache()
+
+    for _ in range(5):
+        allowed, _ = accounting_instance.check_quota("gpt-4", "user1", "app", 1, 0.1)
+        assert allowed

--- a/tests/core/test_quota_service.py
+++ b/tests/core/test_quota_service.py
@@ -147,10 +147,9 @@ def test_check_quota_different_scopes_in_cache(mock_backend: MagicMock):
     assert "GLOBAL limit: 5.00 requests per 1 minute" in reason
 
     mock_backend.get_usage_limits.assert_called_once()
-    mock_backend.get_accounting_entries_for_quota.assert_called_once()
-    assert mock_backend.get_accounting_entries_for_quota.call_args.kwargs['limit_type'] == LimitType.REQUESTS
-    assert mock_backend.get_accounting_entries_for_quota.call_args.kwargs['model'] is None
-    assert mock_backend.get_accounting_entries_for_quota.call_args.kwargs['username'] is None
+    assert mock_backend.get_accounting_entries_for_quota.call_count == 3
+    call_kwargs_list = [call.kwargs for call in mock_backend.get_accounting_entries_for_quota.call_args_list]
+    assert any(kw['limit_type'] == LimitType.REQUESTS and kw['model'] is None and kw['username'] is None for kw in call_kwargs_list)
 
 
 def test_check_quota_token_limits(mock_backend: MagicMock):

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 # --- Revision IDs (obtained from previous steps) ---
 REVISION_INITIAL_TABLES = "82f27c891782"
 REVISION_ADD_NOTES_COLUMN = "ba9718840e75"
+REVISION_ADD_INDICES = "cc98ec5bdfa4"
 
 
 # --- Fixtures ---
@@ -117,10 +118,10 @@ def test_sqlite_initial_migration_creates_schema(sqlite_db_url, set_db_url_env, 
     # 4. Verify alembic_version table and its content
     assert "alembic_version" in current_tables, "alembic_version table not found."
     
-    # The `run_migrations` should bring it to head, which is REVISION_ADD_NOTES_COLUMN
-    # because that's the latest migration we generated.
-    assert get_alembic_revision(engine) == REVISION_ADD_NOTES_COLUMN, \
-        f"Alembic version should be at {REVISION_ADD_NOTES_COLUMN} after initial run_migrations."
+    # The `run_migrations` should bring it to head, which is REVISION_ADD_INDICES
+    # because that's now the latest migration we generated.
+    assert get_alembic_revision(engine) == REVISION_ADD_INDICES, \
+        f"Alembic version should be at {REVISION_ADD_INDICES} after initial run_migrations."
 
 def test_sqlite_applies_new_migration_and_preserves_data(sqlite_db_url, set_db_url_env, alembic_config):
     logger.info(f"Running test_sqlite_applies_new_migration_and_preserves_data with DB URL: {sqlite_db_url}")
@@ -169,14 +170,14 @@ def test_sqlite_applies_new_migration_and_preserves_data(sqlite_db_url, set_db_u
     assert result == 1, "Dummy data not inserted correctly."
     logger.info("Dummy data inserted.")
 
-    # 3. Run Migrations Again (this should apply the "add_notes_column" migration)
-    logger.info("Running migrations again to apply 'add_notes_column'.")
-    run_migrations(db_url=sqlite_db_url) # This should upgrade to head (REVISION_ADD_NOTES_COLUMN)
+    # 3. Run Migrations Again (this should apply any new migrations including 'add_indices')
+    logger.info("Running migrations again to apply remaining migrations.")
+    run_migrations(db_url=sqlite_db_url)  # This should upgrade to head (REVISION_ADD_INDICES)
 
     # 4. Verify Schema Update
     current_revision_after_second_run = get_alembic_revision(engine)
     logger.info(f"Revision after second run_migrations: {current_revision_after_second_run}")
-    assert current_revision_after_second_run == REVISION_ADD_NOTES_COLUMN
+    assert current_revision_after_second_run == REVISION_ADD_INDICES
     
     accounting_columns_after = get_column_names(engine, "accounting_entries")
     logger.info(f"Columns in accounting_entries after 'add_notes' migration: {accounting_columns_after}")
@@ -262,8 +263,8 @@ def test_postgresql_initial_migration_creates_schema(postgresql_engine, set_db_u
         f"Not all expected tables found in PG. Missing: {expected_tables - current_tables}"
     
     assert "alembic_version" in current_tables, "alembic_version table not found in PG."
-    assert get_alembic_revision(postgresql_engine) == REVISION_ADD_NOTES_COLUMN, \
-        f"Alembic version in PG should be at {REVISION_ADD_NOTES_COLUMN}."
+    assert get_alembic_revision(postgresql_engine) == REVISION_ADD_INDICES, \
+        f"Alembic version in PG should be at {REVISION_ADD_INDICES}."
 
 @pytest.mark.skipif(not TEST_POSTGRESQL_URL, reason="TEST_POSTGRESQL_DB_URL not set")
 def test_postgresql_applies_new_migration_and_preserves_data(postgresql_engine, set_db_url_env, postgresql_alembic_config):
@@ -304,12 +305,12 @@ def test_postgresql_applies_new_migration_and_preserves_data(postgresql_engine, 
     logger.info("Dummy data inserted in PG.")
 
     # 3. Run Migrations Again
-    logger.info("Running migrations again on PG to apply 'add_notes_column'.")
-    assert TEST_POSTGRESQL_URL is not None # Ensure for type checker
+    logger.info("Running migrations again on PG to apply remaining migrations.")
+    assert TEST_POSTGRESQL_URL is not None  # Ensure for type checker
     run_migrations(db_url=TEST_POSTGRESQL_URL)
 
     # 4. Verify Schema Update
-    assert get_alembic_revision(postgresql_engine) == REVISION_ADD_NOTES_COLUMN
+    assert get_alembic_revision(postgresql_engine) == REVISION_ADD_INDICES
     accounting_columns_after = get_column_names(postgresql_engine, "accounting_entries")
     assert "notes" in accounting_columns_after, "'notes' column not found in PG after migration."
 
@@ -361,5 +362,5 @@ def test_postgresql_applies_new_migration_and_preserves_data(postgresql_engine, 
 # - Tests for SQLite and PostgreSQL follow similar patterns.
 # - PostgreSQL tests are skipped if TEST_POSTGRESQL_DB_URL is not set.
 # - PostgreSQL setup fixture attempts to clean tables for a consistent test environment.
-# - The test for initial migration checks against REVISION_ADD_NOTES_COLUMN because run_migrations() brings to head.
+# - The test for initial migration checks against REVISION_ADD_INDICES because run_migrations() brings to head.
 # - The test for applying new migration correctly uses alembic_command.upgrade() to go to a specific prior revision.


### PR DESCRIPTION
## Summary
- support '*' wildcard values and unlimited/deny limit values in quota checks
- sort limit evaluation by specificity
- add DB indices on model, username, and caller_name
- document wildcards and limit values in README and CLI help
- add migration for new indices
- add tests for wildcard and unlimited rules
- fix tests to expect new Alembic revision

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845f01447e8833396135e619dfc53f6