### PR TITLE
Add tracking variant returning remaining limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A Python package for tracking and analyzing LLM usage across different models an
 - Strict model name validation
 - Automatic timestamp handling
 - Comprehensive audit logging for all LLM interactions
+- Retrieve remaining quota information after logging usage
 
 ## Installation
 
@@ -67,6 +68,17 @@ accounting.track_usage(
     project="my_project",  # Optional: name of the project (overrides default project_name)
     timestamp=None         # Optional: if None, current time will be used
 )
+
+# Track usage and get remaining limits
+remaining = accounting.track_usage_with_remaining_limits(
+    model="gpt-4",
+    prompt_tokens=100,
+    completion_tokens=50,
+    total_tokens=150,
+    cost=0.002,
+)
+for limit, left in remaining:
+    print(f"{limit.scope} {limit.limit_type}: {left} remaining")
 
 # Get statistics
 end_date = datetime.now()

--- a/src/llm_accounting/__init__.py
+++ b/src/llm_accounting/__init__.py
@@ -128,6 +128,50 @@ class LLMAccounting:
         )
         self.backend.insert_usage(entry)
 
+    def track_usage_with_remaining_limits(
+        self,
+        model: str,
+        prompt_tokens: Optional[int] = None,
+        completion_tokens: Optional[int] = None,
+        total_tokens: Optional[int] = None,
+        local_prompt_tokens: Optional[int] = None,
+        local_completion_tokens: Optional[int] = None,
+        local_total_tokens: Optional[int] = None,
+        cost: float = 0.0,
+        execution_time: float = 0.0,
+        timestamp: Optional[datetime] = None,
+        caller_name: Optional[str] = None,
+        username: Optional[str] = None,
+        cached_tokens: int = 0,
+        reasoning_tokens: int = 0,
+        project: Optional[str] = None,
+    ) -> List[Tuple[UsageLimitDTO, float]]:
+        """Track usage and return remaining quota for all applicable limits."""
+        self.track_usage(
+            model=model,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+            local_prompt_tokens=local_prompt_tokens,
+            local_completion_tokens=local_completion_tokens,
+            local_total_tokens=local_total_tokens,
+            cost=cost,
+            execution_time=execution_time,
+            timestamp=timestamp,
+            caller_name=caller_name,
+            username=username,
+            cached_tokens=cached_tokens,
+            reasoning_tokens=reasoning_tokens,
+            project=project,
+        )
+
+        return self.quota_service.get_remaining_limits(
+            model=model,
+            username=username if username is not None else self.user_name,
+            caller_name=caller_name if caller_name is not None else self.app_name,
+            project_name=project if project is not None else self.project_name,
+        )
+
     def get_period_stats(self, start: datetime, end: datetime) -> UsageStats:
         """Get aggregated statistics for a time period"""
         self.backend._ensure_connected()

--- a/tests/core/test_track_usage_remaining_limits.py
+++ b/tests/core/test_track_usage_remaining_limits.py
@@ -1,0 +1,71 @@
+import math
+from llm_accounting.models.limits import LimitScope, LimitType, TimeInterval
+
+
+def test_track_usage_with_remaining_limits(accounting):
+    with accounting:
+        accounting.set_usage_limit(
+            scope=LimitScope.USER,
+            limit_type=LimitType.TOTAL_TOKENS,
+            max_value=100,
+            interval_unit=TimeInterval.DAY,
+            interval_value=1,
+            username="alice",
+        )
+        accounting.set_usage_limit(
+            scope=LimitScope.GLOBAL,
+            limit_type=LimitType.COST,
+            max_value=10,
+            interval_unit=TimeInterval.DAY,
+            interval_value=1,
+        )
+        accounting.quota_service.refresh_limits_cache()
+
+        remaining = accounting.track_usage_with_remaining_limits(
+            model="gpt-4",
+            prompt_tokens=40,
+            completion_tokens=10,
+            total_tokens=50,
+            cost=1.0,
+            username="alice",
+            caller_name="app",
+        )
+
+        results = {(lim.scope, lim.limit_type): rem for lim, rem in remaining}
+        assert results[(LimitScope.USER.value, LimitType.TOTAL_TOKENS.value)] == 50.0
+        assert results[(LimitScope.GLOBAL.value, LimitType.COST.value)] == 9.0
+
+
+def test_track_usage_remaining_limits_special_values(accounting):
+    with accounting:
+        accounting.set_usage_limit(
+            scope=LimitScope.MODEL,
+            limit_type=LimitType.REQUESTS,
+            model="*",
+            max_value=0,
+            interval_unit=TimeInterval.DAY,
+            interval_value=1,
+        )
+        accounting.set_usage_limit(
+            scope=LimitScope.MODEL,
+            limit_type=LimitType.REQUESTS,
+            model="gpt-4",
+            max_value=-1,
+            interval_unit=TimeInterval.DAY,
+            interval_value=1,
+        )
+        accounting.quota_service.refresh_limits_cache()
+
+        remaining = accounting.track_usage_with_remaining_limits(
+            model="gpt-4",
+            caller_name="app",
+            username="alice",
+        )
+
+        results = {
+            (lim.scope, lim.model, lim.limit_type): rem for lim, rem in remaining
+        }
+        assert results[(LimitScope.MODEL.value, "*", LimitType.REQUESTS.value)] == 0.0
+        assert math.isinf(
+            results[(LimitScope.MODEL.value, "gpt-4", LimitType.REQUESTS.value)]
+        )


### PR DESCRIPTION
## Summary
- add `track_usage_with_remaining_limits` that returns remaining quota after logging usage
- expose helper in `QuotaService` and `QuotaServiceLimitEvaluator` to compute remaining limits
- document new feature in README
- add unit test for remaining-limit feedback
- test edge cases for wildcards, zero and unlimited limits

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846072c32348333b527ee472116b748