### PR TITLE
Fix log_type documentation and test CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ The `src/` directory holds the core logic of the `llm-accounting` library.
 This is the main package for the LLM accounting system.
 
 - `__init__.py`: Initializes the `llm_accounting` package.
-- `audit_log.py`: Manages the auditing of LLM usage, recording events and interactions.
+- `audit_log.py`: Manages the auditing of LLM usage, recording events and interactions. Each audit entry includes a `log_type` field categorizing the entry (e.g., `prompt`, `response`, or custom event names).
 - `db_migrations.py`: Contains functions related to database migrations.
 
 #### `src/llm_accounting/backends/`

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Logs a generic event to the audit log. This is useful for recording custom event
 - `--app-name` (string, required): Name of the application.
 - `--user-name` (string, required): Name of the user.
 - `--model` (string, required): Name of the LLM model associated with the event.
-- `--log-type` (string, required): Type of the log entry (e.g., 'info', 'warning', 'error', 'feedback', or a custom type).
+- `--log-type` (string, required): Type of the log entry (e.g., 'prompt', 'response', 'event', or any custom type).
 - `--prompt-text` (string, optional): Text of the prompt, if relevant.
 - `--response-text` (string, optional): Text of the response, if relevant.
 - `--remote-completion-id` (string, optional): ID of the remote completion, if relevant.
@@ -154,7 +154,7 @@ llm-accounting log-event \
     --app-name my-app \
     --user-name testuser \
     --model gpt-4 \
-    --log-type info \
+    --log-type event \
     --prompt-text "User reported positive feedback." \
     --project "Alpha" \
     --timestamp "2024-01-15T10:30:00"

--- a/tests/cli/test_cli_log_event.py
+++ b/tests/cli/test_cli_log_event.py
@@ -197,3 +197,17 @@ def test_log_event_timestamp_parse_error(capsys, temp_db_path_with_audit_log_tab
         audit_logger: AuditLogger = accounting.audit_logger
         entries = audit_logger.get_entries(app_name=app_name, user_name=user_name)
     assert len(entries) == 0
+
+
+def test_log_event_missing_log_type(temp_db_path_with_audit_log_table):
+    """CLI should exit with error when --log-type is missing."""
+    db_file = temp_db_path_with_audit_log_table
+    command_args = [
+        "log-event",
+        "--app-name", "app",
+        "--user-name", "user",
+        "--model", "gpt-3.5",
+    ]
+
+    with pytest.raises(SystemExit):
+        run_cli_command(db_file, command_args)


### PR DESCRIPTION
## Summary
- clarify log_event CLI docs to use `prompt`, `response`, or `event`
- mention `log_type` field in AGENTS guidelines
- add CLI test for missing `--log-type` argument

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684682dd6cb88333b93f369b15b9de7b