### PR TITLE
Add project enforcement and management

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A Python package for tracking and analyzing LLM usage across different models an
 - Automatic timestamp handling
 - Comprehensive audit logging for all LLM interactions
 - Retrieve remaining quota information after logging usage
+- Optional enforcement of allowed project names with `projects` management commands
 
 ## Installation
 
@@ -113,6 +114,7 @@ The following options can be used with any `llm-accounting` command:
 - `--project-name <name>`: Default project name to associate with usage entries. Can be overridden by command-specific `--project`.
 - `--app-name <name>`: Default application name to associate with usage entries. Can be overridden by command-specific `--caller-name`.
 - `--user-name <name>`: Default user name to associate with usage entries. Can be overridden by command-specific `--username`. Defaults to current system user.
+- `--enforce-project-names`: When set, project names supplied to commands must exist in the project dictionary.
 
 ```bash
 # Track a new usage entry (model name is required, timestamp is optional)
@@ -256,6 +258,17 @@ llm-accounting limits delete --id 1
 You can specify the database backend directly via the CLI using the `--db-backend` option. This allows you to switch between `sqlite` (default) and `postgresql` without modifying code.
 
 Audit logs can optionally use a different backend by providing the `--audit-db-backend` and related options.
+
+### Project Management
+
+The `projects` command manages the list of allowed project names when `--enforce-project-names` is used.
+
+```bash
+llm-accounting projects add MyProj
+llm-accounting projects list
+llm-accounting projects update MyProj NewName
+llm-accounting projects delete NewName
+```
 
 ```bash
 # Use SQLite backend (default behavior, --db-backend can be omitted)

--- a/alembic/versions/f873f865a1ae_add_projects_table.py
+++ b/alembic/versions/f873f865a1ae_add_projects_table.py
@@ -1,0 +1,27 @@
+"""add projects table
+
+Revision ID: f873f865a1ae
+Revises: cc98ec5bdfa4
+Create Date: 2025-07-01 00:00:00
+
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'f873f865a1ae'
+down_revision: Union[str, None] = 'cc98ec5bdfa4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'projects',
+        sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column('name', sa.String(), nullable=False, unique=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('projects')

--- a/src/llm_accounting/backends/base.py
+++ b/src/llm_accounting/backends/base.py
@@ -235,3 +235,25 @@ class BaseBackend(ABC):
     ) -> List[AuditLogEntry]:
         """Retrieve audit log entries based on filter criteria."""
         pass
+
+    # --- Project Management ---
+
+    @abstractmethod
+    def create_project(self, name: str) -> None:
+        """Create a new allowed project name."""
+        pass
+
+    @abstractmethod
+    def list_projects(self) -> List[str]:
+        """Return the list of allowed project names."""
+        pass
+
+    @abstractmethod
+    def update_project(self, name: str, new_name: str) -> None:
+        """Rename an existing project."""
+        pass
+
+    @abstractmethod
+    def delete_project(self, name: str) -> None:
+        """Delete a project from the dictionary."""
+        pass

--- a/src/llm_accounting/backends/mock_backend.py
+++ b/src/llm_accounting/backends/mock_backend.py
@@ -27,6 +27,7 @@ class MockBackend(BaseBackend):
         self.next_limit_id: int = 1
         self.initialized = False
         self.closed = False
+        self.projects: List[str] = []
 
         self._connection_manager = MockConnectionManager(self)
         self._usage_manager = MockUsageManager(self)
@@ -132,3 +133,19 @@ class MockBackend(BaseBackend):
         logging.debug("MockBackend: Retrieving audit log entries.")
         # In a real mock, you might return a predefined list or filter stored entries
         return []
+
+    # --- Project management ---
+
+    def create_project(self, name: str) -> None:
+        self.projects.append(name)
+
+    def list_projects(self) -> List[str]:
+        return list(self.projects)
+
+    def update_project(self, name: str, new_name: str) -> None:
+        if name in self.projects:
+            self.projects[self.projects.index(name)] = new_name
+
+    def delete_project(self, name: str) -> None:
+        if name in self.projects:
+            self.projects.remove(name)

--- a/src/llm_accounting/backends/postgresql.py
+++ b/src/llm_accounting/backends/postgresql.py
@@ -21,6 +21,7 @@ from .postgresql_backend_parts.data_inserter import DataInserter
 from .postgresql_backend_parts.data_deleter import DataDeleter
 from .postgresql_backend_parts.query_executor import QueryExecutor
 from .postgresql_backend_parts.limit_manager import LimitManager
+from .postgresql_backend_parts.project_manager import ProjectManager
 
 logger = logging.getLogger(__name__)
 
@@ -47,11 +48,12 @@ class PostgreSQLBackend(BaseBackend):
         logger.info("PostgreSQLBackend initialized with connection string.")
 
         self.connection_manager = ConnectionManager(self)
-        self.schema_manager = SchemaManager(self) 
+        self.schema_manager = SchemaManager(self)
         self.data_inserter = DataInserter(self)
         self.data_deleter = DataDeleter(self)
         self.query_executor = QueryExecutor(self)
         self.limit_manager = LimitManager(self, self.data_inserter)
+        self.project_manager = ProjectManager(self)
 
     def _read_postgres_migration_cache(self, migration_cache_file: Path, current_conn_hash: int) -> Optional[str]:
         if migration_cache_file.exists():
@@ -411,3 +413,17 @@ class PostgreSQLBackend(BaseBackend):
             logger.error(f"Unexpected error retrieving audit log entries: {e}")
             active_conn.rollback()
             raise RuntimeError(f"Unexpected error occurred while retrieving audit log entries: {e}") from e
+
+    # --- Project management ---
+
+    def create_project(self, name: str) -> None:
+        self.project_manager.create_project(name)
+
+    def list_projects(self) -> List[str]:
+        return self.project_manager.list_projects()
+
+    def update_project(self, name: str, new_name: str) -> None:
+        self.project_manager.update_project(name, new_name)
+
+    def delete_project(self, name: str) -> None:
+        self.project_manager.delete_project(name)

--- a/src/llm_accounting/backends/postgresql_backend_parts/project_manager.py
+++ b/src/llm_accounting/backends/postgresql_backend_parts/project_manager.py
@@ -1,0 +1,35 @@
+import logging
+from typing import List
+
+class ProjectManager:
+    def __init__(self, backend_instance):
+        self.backend = backend_instance
+        self.logger = logging.getLogger(__name__)
+
+    def create_project(self, name: str) -> None:
+        self.backend._ensure_connected()
+        assert self.backend.conn is not None
+        with self.backend.conn.cursor() as cur:
+            cur.execute("INSERT INTO projects (name) VALUES (%s)", (name,))
+        self.backend.conn.commit()
+
+    def list_projects(self) -> List[str]:
+        self.backend._ensure_connected()
+        assert self.backend.conn is not None
+        with self.backend.conn.cursor() as cur:
+            cur.execute("SELECT name FROM projects ORDER BY name")
+            return [row[0] for row in cur.fetchall()]
+
+    def update_project(self, name: str, new_name: str) -> None:
+        self.backend._ensure_connected()
+        assert self.backend.conn is not None
+        with self.backend.conn.cursor() as cur:
+            cur.execute("UPDATE projects SET name = %s WHERE name = %s", (new_name, name))
+        self.backend.conn.commit()
+
+    def delete_project(self, name: str) -> None:
+        self.backend._ensure_connected()
+        assert self.backend.conn is not None
+        with self.backend.conn.cursor() as cur:
+            cur.execute("DELETE FROM projects WHERE name = %s", (name,))
+        self.backend.conn.commit()

--- a/src/llm_accounting/backends/sqlite.py
+++ b/src/llm_accounting/backends/sqlite.py
@@ -12,6 +12,7 @@ from .sqlite_backend_parts.query_executor import SQLiteQueryExecutor
 from .sqlite_backend_parts.usage_manager import SQLiteUsageManager
 from .sqlite_backend_parts.limit_manager import SQLiteLimitManager
 from .sqlite_backend_parts.audit_log_manager import SQLiteAuditLogManager
+from .sqlite_backend_parts.project_manager import SQLiteProjectManager
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +31,7 @@ class SQLiteBackend(BaseBackend):
         self.usage_manager = SQLiteUsageManager(self.connection_manager)
         self.limit_manager = SQLiteLimitManager(self.connection_manager)
         self.audit_log_manager = SQLiteAuditLogManager(self.connection_manager)
+        self.project_manager = SQLiteProjectManager(self.connection_manager)
 
     def initialize(self) -> None:
         self.connection_manager.initialize()
@@ -153,3 +155,17 @@ class SQLiteBackend(BaseBackend):
         """Retrieve aggregated usage costs for a user."""
         conn = self.connection_manager.get_connection()
         return self.usage_manager.get_usage_costs(conn, user_id, start_date, end_date)
+
+    # --- Project management ---
+
+    def create_project(self, name: str) -> None:
+        self.project_manager.create_project(name)
+        
+    def list_projects(self) -> List[str]:
+        return self.project_manager.list_projects()
+
+    def update_project(self, name: str, new_name: str) -> None:
+        self.project_manager.update_project(name, new_name)
+
+    def delete_project(self, name: str) -> None:
+        self.project_manager.delete_project(name)

--- a/src/llm_accounting/backends/sqlite_backend_parts/project_manager.py
+++ b/src/llm_accounting/backends/sqlite_backend_parts/project_manager.py
@@ -1,0 +1,32 @@
+import logging
+from typing import List
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
+
+class SQLiteProjectManager:
+    def __init__(self, connection_manager):
+        self.connection_manager = connection_manager
+        self.logger = logging.getLogger(__name__)
+
+    def create_project(self, name: str) -> None:
+        conn = self.connection_manager.get_connection()
+        conn.execute(text("INSERT INTO projects (name) VALUES (:name)"), {"name": name})
+        conn.commit()
+
+    def list_projects(self) -> List[str]:
+        conn = self.connection_manager.get_connection()
+        result = conn.execute(text("SELECT name FROM projects ORDER BY name"))
+        return [row.name for row in result.fetchall()]
+
+    def update_project(self, name: str, new_name: str) -> None:
+        conn = self.connection_manager.get_connection()
+        conn.execute(
+            text("UPDATE projects SET name = :new_name WHERE name = :name"),
+            {"new_name": new_name, "name": name},
+        )
+        conn.commit()
+
+    def delete_project(self, name: str) -> None:
+        conn = self.connection_manager.get_connection()
+        conn.execute(text("DELETE FROM projects WHERE name = :name"), {"name": name})
+        conn.commit()

--- a/src/llm_accounting/cli/commands/projects.py
+++ b/src/llm_accounting/cli/commands/projects.py
@@ -1,0 +1,26 @@
+from llm_accounting import LLMAccounting
+from ..utils import console
+
+
+def run_project_add(args, accounting: LLMAccounting) -> None:
+    accounting.quota_service.create_project(args.name)
+    console.print(f"[green]Project '{args.name}' added.[/green]")
+
+
+def run_project_list(args, accounting: LLMAccounting) -> None:
+    projects = accounting.quota_service.list_projects()
+    if not projects:
+        console.print("[yellow]No projects defined.[/yellow]")
+    else:
+        for p in projects:
+            console.print(p)
+
+
+def run_project_update(args, accounting: LLMAccounting) -> None:
+    accounting.quota_service.update_project(args.name, args.new_name)
+    console.print(f"[green]Project '{args.name}' renamed to '{args.new_name}'.[/green]")
+
+
+def run_project_delete(args, accounting: LLMAccounting) -> None:
+    accounting.quota_service.delete_project(args.name)
+    console.print(f"[green]Project '{args.name}' deleted.[/green]")

--- a/src/llm_accounting/cli/parsers.py
+++ b/src/llm_accounting/cli/parsers.py
@@ -6,6 +6,12 @@ from llm_accounting.cli.commands.track import run_track
 from llm_accounting.cli.commands.limits import set_limit, list_limits, delete_limit
 from llm_accounting.models.limits import LimitScope, LimitType, TimeInterval
 from llm_accounting.cli.commands.log_event import run_log_event
+from llm_accounting.cli.commands.projects import (
+    run_project_add,
+    run_project_list,
+    run_project_update,
+    run_project_delete,
+)
 
 
 def add_stats_parser(subparsers):
@@ -235,3 +241,24 @@ def add_log_event_parser(subparsers):
     parser.add_argument("--project", type=str, help="Project associated with the event")
     parser.add_argument("--timestamp", type=str, help="Timestamp of the event (YYYY-MM-DD HH:MM:SS or ISO format, default: current time)")
     parser.set_defaults(func=run_log_event)
+
+
+def add_projects_parser(subparsers):
+    parser = subparsers.add_parser("projects", help="Manage allowed projects")
+    proj_sub = parser.add_subparsers(dest="projects_command", required=True)
+
+    add_p = proj_sub.add_parser("add", help="Add a new project")
+    add_p.add_argument("name", type=str)
+    add_p.set_defaults(func=run_project_add)
+
+    list_p = proj_sub.add_parser("list", help="List projects")
+    list_p.set_defaults(func=run_project_list)
+
+    upd_p = proj_sub.add_parser("update", help="Rename a project")
+    upd_p.add_argument("name", type=str)
+    upd_p.add_argument("new_name", type=str)
+    upd_p.set_defaults(func=run_project_update)
+
+    del_p = proj_sub.add_parser("delete", help="Delete a project")
+    del_p.add_argument("name", type=str)
+    del_p.set_defaults(func=run_project_delete)

--- a/src/llm_accounting/cli/utils.py
+++ b/src/llm_accounting/cli/utils.py
@@ -36,6 +36,7 @@ def get_accounting(
     project_name: Optional[str] = None,
     app_name: Optional[str] = None,
     user_name: Optional[str] = None,
+    enforce_project_names: bool = False,
 ):
     """Get an LLMAccounting instance with the specified backend"""
     if db_backend == "sqlite":
@@ -88,6 +89,7 @@ def get_accounting(
         project_name=project_name,
         app_name=app_name,
         user_name=default_user_name,
+        enforce_project_names=enforce_project_names,
     )
     return acc
 

--- a/src/llm_accounting/models/__init__.py
+++ b/src/llm_accounting/models/__init__.py
@@ -2,5 +2,6 @@ from .accounting import AccountingEntry
 from .audit import AuditLogEntryModel
 from .base import Base
 from .limits import UsageLimit
+from .project import Project
 
-__all__ = ["Base", "AccountingEntry", "AuditLogEntryModel", "UsageLimit"]
+__all__ = ["Base", "AccountingEntry", "AuditLogEntryModel", "UsageLimit", "Project"]

--- a/src/llm_accounting/models/project.py
+++ b/src/llm_accounting/models/project.py
@@ -1,0 +1,13 @@
+from sqlalchemy import Column, Integer, String
+
+from llm_accounting.models.base import Base
+
+class Project(Base):
+    __tablename__ = "projects"
+    __table_args__ = {"extend_existing": True}
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String, nullable=False, unique=True)
+
+    def __repr__(self) -> str:
+        return f"<Project(id={self.id}, name='{self.name}')>"

--- a/src/llm_accounting/services/quota_service.py
+++ b/src/llm_accounting/services/quota_service.py
@@ -29,6 +29,10 @@ class QuotaService:
         self._denial_cache.clear() # Clear the denial cache
         logger.info("Denial cache cleared due to limits cache refresh.")
 
+    def refresh_projects_cache(self) -> None:
+        """Refreshes the projects cache from the backend."""
+        self.cache_manager.refresh_projects_cache()
+
     def insert_limit(self, limit: UsageLimitDTO) -> None:
         """Inserts a new usage limit and refreshes the cache."""
         self.backend.insert_usage_limit(limit)
@@ -38,6 +42,25 @@ class QuotaService:
         """Deletes a usage limit and refreshes the cache."""
         self.backend.delete_usage_limit(limit_id)
         self.refresh_limits_cache() # Use the existing refresh_limits_cache method
+
+    # --- Project management ---
+
+    def create_project(self, name: str) -> None:
+        self.backend.create_project(name)
+        self.refresh_projects_cache()
+
+    def list_projects(self) -> List[str]:
+        if self.cache_manager.projects_cache is None:
+            self.cache_manager._load_projects_from_backend()
+        return self.cache_manager.projects_cache
+
+    def update_project(self, name: str, new_name: str) -> None:
+        self.backend.update_project(name, new_name)
+        self.refresh_projects_cache()
+
+    def delete_project(self, name: str) -> None:
+        self.backend.delete_project(name)
+        self.refresh_projects_cache()
 
     def check_quota(
         self,

--- a/src/llm_accounting/services/quota_service_parts/_cache_manager.py
+++ b/src/llm_accounting/services/quota_service_parts/_cache_manager.py
@@ -6,13 +6,24 @@ class QuotaServiceCacheManager:
     def __init__(self, backend: BaseBackend):
         self.backend = backend
         self.limits_cache: Optional[List[UsageLimitDTO]] = None
+        self.projects_cache: Optional[List[str]] = None
         self._load_limits_from_backend()
+        self._load_projects_from_backend()
 
     def _load_limits_from_backend(self) -> None:
         """Loads all usage limits from the backend into the cache."""
         self.limits_cache = self.backend.get_usage_limits()
 
+    def _load_projects_from_backend(self) -> None:
+        """Loads allowed project names from the backend."""
+        self.projects_cache = self.backend.list_projects()
+
     def refresh_limits_cache(self) -> None:
         """Refreshes the limits cache from the backend."""
         self.limits_cache = None
         self._load_limits_from_backend()
+
+    def refresh_projects_cache(self) -> None:
+        """Refreshes the project name cache from the backend."""
+        self.projects_cache = None
+        self._load_projects_from_backend()

--- a/tests/backends/mock_backends.py
+++ b/tests/backends/mock_backends.py
@@ -116,6 +116,18 @@ class MockBackend(BaseBackend):
         # Minimal implementation to satisfy abstract method
         return 0.0
 
+    def create_project(self, name: str) -> None:
+        pass
+
+    def list_projects(self) -> List[str]:
+        return []
+
+    def update_project(self, name: str, new_name: str) -> None:
+        pass
+
+    def delete_project(self, name: str) -> None:
+        pass
+
 
 class IncompleteBackend(BaseBackend):
     """A mock backend that doesn't implement all required methods for BaseBackend interface testing."""

--- a/tests/cli/test_cli_projects.py
+++ b/tests/cli/test_cli_projects.py
@@ -1,0 +1,35 @@
+import sys
+from unittest.mock import patch
+from llm_accounting.cli.main import main as cli_main
+from llm_accounting import LLMAccounting, SQLiteBackend
+
+
+def run_cli(db_path, args_list):
+    with patch.object(sys, 'argv', ['cli_main'] + args_list):
+        cli_main()
+
+
+def test_cli_project_management(tmp_path, capsys):
+    db_path = str(tmp_path / 'proj.sqlite')
+    backend = SQLiteBackend(db_path=db_path)
+    acc = LLMAccounting(backend=backend)
+    with patch('llm_accounting.cli.utils.get_accounting', return_value=acc):
+        run_cli(db_path, ['projects', 'add', 'Alpha'])
+        captured = capsys.readouterr().out
+        assert "Project 'Alpha' added." in captured
+
+        run_cli(db_path, ['projects', 'list'])
+        captured = capsys.readouterr().out
+        assert 'Alpha' in captured
+
+        run_cli(db_path, ['projects', 'update', 'Alpha', 'Beta'])
+        captured = capsys.readouterr().out
+        assert "renamed to 'Beta'" in captured
+
+        run_cli(db_path, ['projects', 'delete', 'Beta'])
+        captured = capsys.readouterr().out
+        assert "Project 'Beta' deleted." in captured
+
+        run_cli(db_path, ['projects', 'list'])
+        captured = capsys.readouterr().out
+        assert 'No projects' in captured

--- a/tests/core/test_project_cache.py
+++ b/tests/core/test_project_cache.py
@@ -1,0 +1,14 @@
+from llm_accounting import LLMAccounting, SQLiteBackend
+
+
+def test_project_cache_refresh(tmp_path):
+    db = str(tmp_path / 'cache.sqlite')
+    backend = SQLiteBackend(db_path=db)
+    acc = LLMAccounting(backend=backend)
+    with acc:
+        acc.quota_service.create_project('One')
+        projects = acc.quota_service.list_projects()
+        assert projects == ['One']
+        acc.quota_service.create_project('Two')
+        projects2 = acc.quota_service.list_projects()
+        assert set(projects2) == {'One', 'Two'}

--- a/tests/core/test_project_enforcement.py
+++ b/tests/core/test_project_enforcement.py
@@ -1,0 +1,16 @@
+from llm_accounting import LLMAccounting, SQLiteBackend
+import pytest
+
+
+def test_project_enforcement(tmp_path):
+    db_path = str(tmp_path / 'enf.sqlite')
+    backend = SQLiteBackend(db_path=db_path)
+    acc = LLMAccounting(backend=backend, enforce_project_names=True)
+    acc.quota_service.create_project('Allowed')
+    with acc:
+        acc.quota_service.refresh_projects_cache()
+        # allowed project
+        acc.track_usage(model='gpt', cost=0.1, prompt_tokens=1, project='Allowed')
+        # invalid project
+        with pytest.raises(ValueError):
+            acc.track_usage(model='gpt', cost=0.1, prompt_tokens=1, project='Bad')

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 # --- Revision IDs (obtained from previous steps) ---
 REVISION_INITIAL_TABLES = "82f27c891782"
 REVISION_ADD_NOTES_COLUMN = "ba9718840e75"
-REVISION_ADD_INDICES = "cc98ec5bdfa4"
+REVISION_ADD_INDICES = "f873f865a1ae"
 
 
 # --- Fixtures ---

--- a/tests/utils/concrete_mock_backend.py
+++ b/tests/utils/concrete_mock_backend.py
@@ -71,3 +71,16 @@ class ConcreteTestBackend(BaseBackend):
         limit: Optional[int] = None,
     ) -> List[AuditLogEntry]:
         return []
+
+    # project management
+    def create_project(self, name: str) -> None:
+        pass
+
+    def list_projects(self) -> List[str]:
+        return []
+
+    def update_project(self, name: str, new_name: str) -> None:
+        pass
+
+    def delete_project(self, name: str) -> None:
+        pass


### PR DESCRIPTION
## Summary
- enforce known projects using CLI flag
- manage projects via new CLI command and backend methods
- cache project names in quota service
- add Alembic migration for projects table
- update README docs
- test project management and enforcement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846c00e4ac48333ac49761aeb6c8d55