### PR TITLE
Add wildcard limit docs and complex usage test

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ llm-accounting select --query "SELECT model, COUNT(*) as count FROM accounting_e
 The `llm-accounting limits` command allows you to manage usage limits for your LLM interactions. It now supports advanced multi-dimensional limiting and rolling time windows. You can set, list, and delete limits based on various scopes (global, model, user, caller, project) and types (requests, input tokens, output tokens, total tokens, cost) over specified time intervals.
 
 Wildcards can be specified using `*` for any of the model, username, caller name, or project name fields. A `max-value` of `0` denies all matching usage, while `-1` allows unlimited usage.
+For example, you can deny all models for a user with `--model "*" --max-value 0` and then add specific limits with `--max-value -1` to allow certain models or projects.
 
 #### Set a Usage Limit
 

--- a/tests/accounting/test_wildcard_limits.py
+++ b/tests/accounting/test_wildcard_limits.py
@@ -4,7 +4,13 @@ from freezegun import freeze_time
 
 from llm_accounting import LLMAccounting
 from llm_accounting.backends.sqlite import SQLiteBackend
-from llm_accounting.models.limits import UsageLimitDTO, LimitScope, LimitType, TimeInterval
+from llm_accounting.models.limits import (
+    UsageLimitDTO,
+    LimitScope,
+    LimitType,
+    TimeInterval,
+)
+
 
 @pytest.fixture
 def sqlite_backend_for_accounting(temp_db_path):
@@ -13,6 +19,7 @@ def sqlite_backend_for_accounting(temp_db_path):
     yield backend
     backend.close()
 
+
 @pytest.fixture
 def accounting_instance(sqlite_backend_for_accounting: SQLiteBackend) -> LLMAccounting:
     acc = LLMAccounting(backend=sqlite_backend_for_accounting)
@@ -20,8 +27,11 @@ def accounting_instance(sqlite_backend_for_accounting: SQLiteBackend) -> LLMAcco
     yield acc
     acc.__exit__(None, None, None)
 
+
 @freeze_time("2024-01-01 00:00:00", tz_offset=0)
-def test_wildcard_deny_and_specific_allow(accounting_instance: LLMAccounting, sqlite_backend_for_accounting: SQLiteBackend):
+def test_wildcard_deny_and_specific_allow(
+    accounting_instance: LLMAccounting, sqlite_backend_for_accounting: SQLiteBackend
+):
     deny_all = UsageLimitDTO(
         scope=LimitScope.MODEL.value,
         model="*",
@@ -48,8 +58,11 @@ def test_wildcard_deny_and_specific_allow(accounting_instance: LLMAccounting, sq
     allowed, _ = accounting_instance.check_quota("gpt-3", None, "app", 1, 0)
     assert not allowed
 
+
 @freeze_time("2024-01-01 00:00:00", tz_offset=0)
-def test_unlimited_limit(accounting_instance: LLMAccounting, sqlite_backend_for_accounting: SQLiteBackend):
+def test_unlimited_limit(
+    accounting_instance: LLMAccounting, sqlite_backend_for_accounting: SQLiteBackend
+):
     unlimited = UsageLimitDTO(
         scope=LimitScope.USER.value,
         username="user1",
@@ -64,3 +77,55 @@ def test_unlimited_limit(accounting_instance: LLMAccounting, sqlite_backend_for_
     for _ in range(5):
         allowed, _ = accounting_instance.check_quota("gpt-4", "user1", "app", 1, 0.1)
         assert allowed
+
+
+@freeze_time("2024-01-01 00:00:00", tz_offset=0)
+def test_wildcard_user_deny_with_project_override(
+    accounting_instance: LLMAccounting, sqlite_backend_for_accounting: SQLiteBackend
+):
+    """Deny all models for a user, allow specific models and project overrides."""
+    deny_all = UsageLimitDTO(
+        scope=LimitScope.USER.value,
+        username="alice",
+        model="*",
+        limit_type=LimitType.REQUESTS.value,
+        max_value=0,
+        interval_unit=TimeInterval.DAY.value,
+        interval_value=1,
+    )
+    allow_gpt4 = UsageLimitDTO(
+        scope=LimitScope.USER.value,
+        username="alice",
+        model="gpt-4",
+        limit_type=LimitType.REQUESTS.value,
+        max_value=-1,
+        interval_unit=TimeInterval.DAY.value,
+        interval_value=1,
+    )
+    allow_project_model = UsageLimitDTO(
+        scope=LimitScope.USER.value,
+        username="alice",
+        model="gpt-3.5",
+        project_name="ProjectX",
+        limit_type=LimitType.REQUESTS.value,
+        max_value=-1,
+        interval_unit=TimeInterval.DAY.value,
+        interval_value=1,
+    )
+    sqlite_backend_for_accounting.insert_usage_limit(deny_all)
+    sqlite_backend_for_accounting.insert_usage_limit(allow_gpt4)
+    sqlite_backend_for_accounting.insert_usage_limit(allow_project_model)
+    accounting_instance.quota_service.refresh_limits_cache()
+
+    allowed, _ = accounting_instance.check_quota("gpt-4", "alice", "client", 1, 0)
+    assert allowed
+    allowed, _ = accounting_instance.check_quota(
+        "gpt-4", "alice", "client", 1, 0, project_name="ProjectX"
+    )
+    assert allowed
+    allowed, _ = accounting_instance.check_quota("gpt-3.5", "alice", "client", 1, 0)
+    assert not allowed
+    allowed, _ = accounting_instance.check_quota(
+        "gpt-3.5", "alice", "client", 1, 0, project_name="ProjectX"
+    )
+    assert allowed


### PR DESCRIPTION
## Summary
- document wildcard limits and override example
- test user-level wildcard deny with project override

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846c7a8f8dc8333a4cd0f60adacaa00