### PR TITLE
Add user dictionary and enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ The following options can be used with any `llm-accounting` command:
 - `--app-name <name>`: Default application name to associate with usage entries. Can be overridden by command-specific `--caller-name`.
 - `--user-name <name>`: Default user name to associate with usage entries. Can be overridden by command-specific `--username`. Defaults to current system user.
 - `--enforce-project-names`: When set, project names supplied to commands must exist in the project dictionary.
+- `--enforce-user-names`: When set, user names supplied to commands must exist in the user dictionary.
 
 ```bash
 # Track a new usage entry (model name is required, timestamp is optional)
@@ -269,6 +270,17 @@ llm-accounting projects add MyProj
 llm-accounting projects list
 llm-accounting projects update MyProj NewName
 llm-accounting projects delete NewName
+```
+
+### User Management
+
+The `users` command manages the list of allowed user names when `--enforce-user-names` is enabled.
+
+```bash
+llm-accounting users add alice --ou-name IT --email alice@example.com
+llm-accounting users list
+llm-accounting users update alice alice2
+llm-accounting users deactivate alice2
 ```
 
 ```bash

--- a/alembic/versions/aa1b2c3d4e5f_add_users_table.py
+++ b/alembic/versions/aa1b2c3d4e5f_add_users_table.py
@@ -1,0 +1,33 @@
+"""add users table
+
+Revision ID: aa1b2c3d4e5f
+Revises: f873f865a1ae
+Create Date: 2025-07-02 00:00:00
+
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'aa1b2c3d4e5f'
+down_revision: Union[str, None] = 'f873f865a1ae'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'users',
+        sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column('user_name', sa.String(length=255), nullable=False, unique=True),
+        sa.Column('ou_name', sa.String(length=255), nullable=True),
+        sa.Column('email', sa.String(length=255), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column('last_enabled_at', sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column('last_disabled_at', sa.DateTime(), nullable=True),
+        sa.Column('enabled', sa.Boolean(), nullable=False, server_default='1'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('users')

--- a/src/llm_accounting/__init__.py
+++ b/src/llm_accounting/__init__.py
@@ -54,6 +54,7 @@ class LLMAccounting:
         user_name: Optional[str] = None,
         audit_backend: Optional[BaseBackend] = None,
         enforce_project_names: bool = False,
+        enforce_user_names: bool = False,
     ):
         """Initialize with optional backends.
 
@@ -70,6 +71,7 @@ class LLMAccounting:
         self.user_name = user_name
         self.audit_logger = AuditLogger(self.audit_backend)
         self.enforce_project_names = enforce_project_names
+        self.enforce_user_names = enforce_user_names
 
     def _ensure_valid_project(self, project: Optional[str]) -> None:
         if not self.enforce_project_names or project is None:
@@ -77,6 +79,13 @@ class LLMAccounting:
         valid_projects = set(self.quota_service.list_projects())
         if project not in valid_projects:
             raise ValueError(f"Project name '{project}' is not in allowed projects")
+
+    def _ensure_valid_user(self, user: Optional[str]) -> None:
+        if not self.enforce_user_names or user is None:
+            return
+        valid_users = {u["user_name"] for u in self.quota_service.list_users()}
+        if user not in valid_users:
+            raise ValueError(f"User name '{user}' is not in allowed users")
 
     def __enter__(self):
         """Initialize the backend when entering context"""
@@ -118,6 +127,8 @@ class LLMAccounting:
     ) -> None:
         """Track a new LLM usage entry"""
         self._ensure_valid_project(project if project is not None else self.project_name)
+        self._ensure_valid_user(username if username is not None else self.user_name)
+        self._ensure_valid_user(username if username is not None else self.user_name)
         self.backend._ensure_connected()
         entry = UsageEntry(
             model=model,
@@ -222,6 +233,7 @@ class LLMAccounting:
     ) -> Tuple[bool, Optional[str]]:
         """Check if the current request exceeds any defined quotas."""
         self._ensure_valid_project(project_name)
+        self._ensure_valid_user(username)
         self.backend._ensure_connected()
         return self.quota_service.check_quota(
             model=model,
@@ -247,6 +259,7 @@ class LLMAccounting:
     ) -> None:
         """Sets a new usage limit."""
         self._ensure_valid_project(project_name)
+        self._ensure_valid_user(username)
         self.backend._ensure_connected()
         limit = UsageLimitDTO(
             scope=scope.value if isinstance(scope, LimitScope) else scope,

--- a/src/llm_accounting/backends/base.py
+++ b/src/llm_accounting/backends/base.py
@@ -257,3 +257,25 @@ class BaseBackend(ABC):
     def delete_project(self, name: str) -> None:
         """Delete a project from the dictionary."""
         pass
+
+    # --- User management ---
+
+    @abstractmethod
+    def create_user(self, user_name: str, ou_name: Optional[str] = None, email: Optional[str] = None) -> None:
+        """Create a new allowed user."""
+        pass
+
+    @abstractmethod
+    def list_users(self) -> List[Dict]:
+        """Return the list of allowed users."""
+        pass
+
+    @abstractmethod
+    def update_user(self, user_name: str, new_name: str) -> None:
+        """Rename an existing user."""
+        pass
+
+    @abstractmethod
+    def set_user_active(self, user_name: str, active: bool) -> None:
+        """Activate or deactivate a user."""
+        pass

--- a/src/llm_accounting/backends/mock_backend.py
+++ b/src/llm_accounting/backends/mock_backend.py
@@ -28,6 +28,7 @@ class MockBackend(BaseBackend):
         self.initialized = False
         self.closed = False
         self.projects: List[str] = []
+        self.users: List[Dict] = []
 
         self._connection_manager = MockConnectionManager(self)
         self._usage_manager = MockUsageManager(self)
@@ -149,3 +150,23 @@ class MockBackend(BaseBackend):
     def delete_project(self, name: str) -> None:
         if name in self.projects:
             self.projects.remove(name)
+
+    # --- User management ---
+
+    def create_user(self, user_name: str, ou_name: Optional[str] = None, email: Optional[str] = None) -> None:
+        self.users.append({"user_name": user_name, "ou_name": ou_name, "email": email, "enabled": True})
+
+    def list_users(self) -> List[Dict]:
+        return list(self.users)
+
+    def update_user(self, user_name: str, new_name: str) -> None:
+        for u in self.users:
+            if u["user_name"] == user_name:
+                u["user_name"] = new_name
+                break
+
+    def set_user_active(self, user_name: str, active: bool) -> None:
+        for u in self.users:
+            if u["user_name"] == user_name:
+                u["enabled"] = active
+                break

--- a/src/llm_accounting/backends/postgresql.py
+++ b/src/llm_accounting/backends/postgresql.py
@@ -22,6 +22,7 @@ from .postgresql_backend_parts.data_deleter import DataDeleter
 from .postgresql_backend_parts.query_executor import QueryExecutor
 from .postgresql_backend_parts.limit_manager import LimitManager
 from .postgresql_backend_parts.project_manager import ProjectManager
+from .postgresql_backend_parts.user_manager import UserManager
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +55,7 @@ class PostgreSQLBackend(BaseBackend):
         self.query_executor = QueryExecutor(self)
         self.limit_manager = LimitManager(self, self.data_inserter)
         self.project_manager = ProjectManager(self)
+        self.user_manager = UserManager(self)
 
     def _read_postgres_migration_cache(self, migration_cache_file: Path, current_conn_hash: int) -> Optional[str]:
         if migration_cache_file.exists():
@@ -427,3 +429,17 @@ class PostgreSQLBackend(BaseBackend):
 
     def delete_project(self, name: str) -> None:
         self.project_manager.delete_project(name)
+
+    # --- User management ---
+
+    def create_user(self, user_name: str, ou_name: str | None = None, email: str | None = None) -> None:
+        self.user_manager.create_user(user_name, ou_name, email)
+
+    def list_users(self) -> List[dict]:
+        return self.user_manager.list_users()
+
+    def update_user(self, user_name: str, new_name: str) -> None:
+        self.user_manager.update_user(user_name, new_name)
+
+    def set_user_active(self, user_name: str, active: bool) -> None:
+        self.user_manager.set_user_active(user_name, active)

--- a/src/llm_accounting/backends/postgresql_backend_parts/user_manager.py
+++ b/src/llm_accounting/backends/postgresql_backend_parts/user_manager.py
@@ -1,0 +1,46 @@
+import logging
+from datetime import datetime
+from typing import List, Dict
+
+class UserManager:
+    def __init__(self, backend_instance):
+        self.backend = backend_instance
+        self.logger = logging.getLogger(__name__)
+
+    def create_user(self, user_name: str, ou_name: str | None = None, email: str | None = None) -> None:
+        self.backend._ensure_connected()
+        assert self.backend.conn is not None
+        with self.backend.conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO users (user_name, ou_name, email, created_at, last_enabled_at, enabled)"
+                " VALUES (%s, %s, %s, %s, %s, TRUE)",
+                (user_name, ou_name, email, datetime.utcnow(), datetime.utcnow()),
+            )
+        self.backend.conn.commit()
+
+    def list_users(self) -> List[Dict]:
+        self.backend._ensure_connected()
+        assert self.backend.conn is not None
+        with self.backend.conn.cursor() as cur:
+            cur.execute("SELECT id, user_name, ou_name, email, created_at, last_enabled_at, last_disabled_at, enabled FROM users ORDER BY user_name")
+            rows = cur.fetchall()
+            columns = [desc[0] for desc in cur.description]
+            return [dict(zip(columns, row)) for row in rows]
+
+    def update_user(self, user_name: str, new_name: str) -> None:
+        self.backend._ensure_connected()
+        assert self.backend.conn is not None
+        with self.backend.conn.cursor() as cur:
+            cur.execute("UPDATE users SET user_name = %s WHERE user_name = %s", (new_name, user_name))
+        self.backend.conn.commit()
+
+    def set_user_active(self, user_name: str, active: bool) -> None:
+        self.backend._ensure_connected()
+        assert self.backend.conn is not None
+        field = "last_enabled_at" if active else "last_disabled_at"
+        with self.backend.conn.cursor() as cur:
+            cur.execute(
+                f"UPDATE users SET {field} = %s, enabled = %s WHERE user_name = %s",
+                (datetime.utcnow(), active, user_name),
+            )
+        self.backend.conn.commit()

--- a/src/llm_accounting/backends/sqlite.py
+++ b/src/llm_accounting/backends/sqlite.py
@@ -13,6 +13,7 @@ from .sqlite_backend_parts.usage_manager import SQLiteUsageManager
 from .sqlite_backend_parts.limit_manager import SQLiteLimitManager
 from .sqlite_backend_parts.audit_log_manager import SQLiteAuditLogManager
 from .sqlite_backend_parts.project_manager import SQLiteProjectManager
+from .sqlite_backend_parts.user_manager import SQLiteUserManager
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +33,7 @@ class SQLiteBackend(BaseBackend):
         self.limit_manager = SQLiteLimitManager(self.connection_manager)
         self.audit_log_manager = SQLiteAuditLogManager(self.connection_manager)
         self.project_manager = SQLiteProjectManager(self.connection_manager)
+        self.user_manager = SQLiteUserManager(self.connection_manager)
 
     def initialize(self) -> None:
         self.connection_manager.initialize()
@@ -169,3 +171,17 @@ class SQLiteBackend(BaseBackend):
 
     def delete_project(self, name: str) -> None:
         self.project_manager.delete_project(name)
+
+    # --- User management ---
+
+    def create_user(self, user_name: str, ou_name: str | None = None, email: str | None = None) -> None:
+        self.user_manager.create_user(user_name, ou_name, email)
+
+    def list_users(self) -> List[dict]:
+        return self.user_manager.list_users()
+
+    def update_user(self, user_name: str, new_name: str) -> None:
+        self.user_manager.update_user(user_name, new_name)
+
+    def set_user_active(self, user_name: str, active: bool) -> None:
+        self.user_manager.set_user_active(user_name, active)

--- a/src/llm_accounting/backends/sqlite_backend_parts/user_manager.py
+++ b/src/llm_accounting/backends/sqlite_backend_parts/user_manager.py
@@ -1,0 +1,56 @@
+import logging
+from datetime import datetime
+from typing import List, Dict
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
+
+class SQLiteUserManager:
+    def __init__(self, connection_manager):
+        self.connection_manager = connection_manager
+        self.logger = logging.getLogger(__name__)
+
+    def create_user(self, user_name: str, ou_name: str | None = None, email: str | None = None) -> None:
+        conn = self.connection_manager.get_connection()
+        conn.execute(
+            text(
+                "INSERT INTO users (user_name, ou_name, email, created_at, last_enabled_at, enabled)"
+                " VALUES (:user_name, :ou_name, :email, :created_at, :last_enabled_at, 1)"
+            ),
+            {
+                "user_name": user_name,
+                "ou_name": ou_name,
+                "email": email,
+                "created_at": datetime.utcnow(),
+                "last_enabled_at": datetime.utcnow(),
+            },
+        )
+        conn.commit()
+
+    def list_users(self) -> List[Dict]:
+        conn = self.connection_manager.get_connection()
+        result = conn.execute(text("SELECT * FROM users ORDER BY user_name"))
+        rows = result.fetchall()
+        return [dict(row._mapping) for row in rows]
+
+    def update_user(self, user_name: str, new_name: str) -> None:
+        conn = self.connection_manager.get_connection()
+        conn.execute(
+            text("UPDATE users SET user_name = :new_name WHERE user_name = :user_name"),
+            {"new_name": new_name, "user_name": user_name},
+        )
+        conn.commit()
+
+    def set_user_active(self, user_name: str, active: bool) -> None:
+        conn = self.connection_manager.get_connection()
+        fields = {
+            "last_enabled_at" if active else "last_disabled_at": datetime.utcnow(),
+            "enabled": 1 if active else 0,
+        }
+        conn.execute(
+            text(
+                f"UPDATE users SET {', '.join(f'{k} = :{k}' for k in fields.keys())} "
+                "WHERE user_name = :user_name"
+            ),
+            {**fields, "user_name": user_name},
+        )
+        conn.commit()

--- a/src/llm_accounting/cli/commands/users.py
+++ b/src/llm_accounting/cli/commands/users.py
@@ -1,0 +1,27 @@
+from llm_accounting import LLMAccounting
+from ..utils import console
+
+
+def run_user_add(args, accounting: LLMAccounting) -> None:
+    accounting.quota_service.create_user(args.name, ou_name=args.ou_name, email=args.email)
+    console.print(f"[green]User '{args.name}' added.[/green]")
+
+
+def run_user_list(args, accounting: LLMAccounting) -> None:
+    users = accounting.quota_service.list_users()
+    if not users:
+        console.print("[yellow]No users defined.[/yellow]")
+    else:
+        for u in users:
+            status = "active" if u["enabled"] else "inactive"
+            console.print(f"{u['user_name']} ({status})")
+
+
+def run_user_update(args, accounting: LLMAccounting) -> None:
+    accounting.quota_service.update_user(args.name, args.new_name)
+    console.print(f"[green]User '{args.name}' renamed to '{args.new_name}'.[/green]")
+
+
+def run_user_deactivate(args, accounting: LLMAccounting) -> None:
+    accounting.quota_service.set_user_active(args.name, False)
+    console.print(f"[green]User '{args.name}' deactivated.[/green]")

--- a/src/llm_accounting/cli/main.py
+++ b/src/llm_accounting/cli/main.py
@@ -6,7 +6,7 @@ from importlib.metadata import version as get_version
 
 from .parsers import (add_purge_parser, add_select_parser, add_stats_parser,
                       add_tail_parser, add_track_parser, add_limits_parser,
-                      add_log_event_parser, add_projects_parser)
+                      add_log_event_parser, add_projects_parser, add_users_parser)
 from .utils import console
 
 
@@ -90,6 +90,11 @@ def main():
         help="Reject operations using project names not present in the project dictionary.",
     )
     parser.add_argument(
+        "--enforce-user-names",
+        action="store_true",
+        help="Reject operations using user names not present in the user dictionary.",
+    )
+    parser.add_argument(
         "--audit-db-backend",
         type=str,
         choices=["sqlite", "postgresql"],
@@ -116,6 +121,7 @@ def main():
     add_limits_parser(subparsers)
     add_log_event_parser(subparsers) # Added from feat/cli-log-event branch
     add_projects_parser(subparsers)
+    add_users_parser(subparsers)
 
     args = parser.parse_args()
 
@@ -139,6 +145,8 @@ def main():
         )
         if args.enforce_project_names:
             kwargs["enforce_project_names"] = True
+        if args.enforce_user_names:
+            kwargs["enforce_user_names"] = True
         accounting = get_accounting(**kwargs)
         with accounting:
             args.func(args, accounting)

--- a/src/llm_accounting/cli/parsers.py
+++ b/src/llm_accounting/cli/parsers.py
@@ -12,6 +12,12 @@ from llm_accounting.cli.commands.projects import (
     run_project_update,
     run_project_delete,
 )
+from llm_accounting.cli.commands.users import (
+    run_user_add,
+    run_user_list,
+    run_user_update,
+    run_user_deactivate,
+)
 
 
 def add_stats_parser(subparsers):
@@ -262,3 +268,26 @@ def add_projects_parser(subparsers):
     del_p = proj_sub.add_parser("delete", help="Delete a project")
     del_p.add_argument("name", type=str)
     del_p.set_defaults(func=run_project_delete)
+
+
+def add_users_parser(subparsers):
+    parser = subparsers.add_parser("users", help="Manage allowed users")
+    user_sub = parser.add_subparsers(dest="users_command", required=True)
+
+    add_u = user_sub.add_parser("add", help="Add a new user")
+    add_u.add_argument("name", type=str)
+    add_u.add_argument("--ou-name", type=str)
+    add_u.add_argument("--email", type=str)
+    add_u.set_defaults(func=run_user_add)
+
+    list_u = user_sub.add_parser("list", help="List users")
+    list_u.set_defaults(func=run_user_list)
+
+    upd_u = user_sub.add_parser("update", help="Rename a user")
+    upd_u.add_argument("name", type=str)
+    upd_u.add_argument("new_name", type=str)
+    upd_u.set_defaults(func=run_user_update)
+
+    deact_u = user_sub.add_parser("deactivate", help="Deactivate a user")
+    deact_u.add_argument("name", type=str)
+    deact_u.set_defaults(func=run_user_deactivate)

--- a/src/llm_accounting/cli/utils.py
+++ b/src/llm_accounting/cli/utils.py
@@ -37,6 +37,7 @@ def get_accounting(
     app_name: Optional[str] = None,
     user_name: Optional[str] = None,
     enforce_project_names: bool = False,
+    enforce_user_names: bool = False,
 ):
     """Get an LLMAccounting instance with the specified backend"""
     if db_backend == "sqlite":
@@ -90,6 +91,7 @@ def get_accounting(
         app_name=app_name,
         user_name=default_user_name,
         enforce_project_names=enforce_project_names,
+        enforce_user_names=enforce_user_names,
     )
     return acc
 

--- a/src/llm_accounting/models/__init__.py
+++ b/src/llm_accounting/models/__init__.py
@@ -3,5 +3,13 @@ from .audit import AuditLogEntryModel
 from .base import Base
 from .limits import UsageLimit
 from .project import Project
+from .user import User
 
-__all__ = ["Base", "AccountingEntry", "AuditLogEntryModel", "UsageLimit", "Project"]
+__all__ = [
+    "Base",
+    "AccountingEntry",
+    "AuditLogEntryModel",
+    "UsageLimit",
+    "Project",
+    "User",
+]

--- a/src/llm_accounting/models/user.py
+++ b/src/llm_accounting/models/user.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+from sqlalchemy import Column, Integer, String, Boolean, DateTime
+
+from .base import Base
+
+class User(Base):
+    __tablename__ = "users"
+    __table_args__ = {"extend_existing": True}
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_name = Column(String(255), nullable=False, unique=True)
+    ou_name = Column(String(255), nullable=True)
+    email = Column(String(255), nullable=True)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    last_enabled_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    last_disabled_at = Column(DateTime, nullable=True)
+    enabled = Column(Boolean, nullable=False, default=True)
+
+    def __repr__(self) -> str:
+        return f"<User(id={self.id}, user_name='{self.user_name}', enabled={self.enabled})>"

--- a/src/llm_accounting/services/quota_service.py
+++ b/src/llm_accounting/services/quota_service.py
@@ -62,6 +62,28 @@ class QuotaService:
         self.backend.delete_project(name)
         self.refresh_projects_cache()
 
+    # --- User management ---
+
+    def refresh_users_cache(self) -> None:
+        self.cache_manager.refresh_users_cache()
+
+    def create_user(self, user_name: str, ou_name: Optional[str] = None, email: Optional[str] = None) -> None:
+        self.backend.create_user(user_name, ou_name, email)
+        self.refresh_users_cache()
+
+    def list_users(self) -> List[dict]:
+        if self.cache_manager.users_cache is None:
+            self.cache_manager._load_users_from_backend()
+        return self.cache_manager.users_cache
+
+    def update_user(self, user_name: str, new_name: str) -> None:
+        self.backend.update_user(user_name, new_name)
+        self.refresh_users_cache()
+
+    def set_user_active(self, user_name: str, active: bool) -> None:
+        self.backend.set_user_active(user_name, active)
+        self.refresh_users_cache()
+
     def check_quota(
         self,
         model: Optional[str],

--- a/src/llm_accounting/services/quota_service_parts/_cache_manager.py
+++ b/src/llm_accounting/services/quota_service_parts/_cache_manager.py
@@ -7,8 +7,10 @@ class QuotaServiceCacheManager:
         self.backend = backend
         self.limits_cache: Optional[List[UsageLimitDTO]] = None
         self.projects_cache: Optional[List[str]] = None
+        self.users_cache: Optional[List[dict]] = None
         self._load_limits_from_backend()
         self._load_projects_from_backend()
+        self._load_users_from_backend()
 
     def _load_limits_from_backend(self) -> None:
         """Loads all usage limits from the backend into the cache."""
@@ -17,6 +19,10 @@ class QuotaServiceCacheManager:
     def _load_projects_from_backend(self) -> None:
         """Loads allowed project names from the backend."""
         self.projects_cache = self.backend.list_projects()
+
+    def _load_users_from_backend(self) -> None:
+        """Loads allowed user names from the backend."""
+        self.users_cache = self.backend.list_users()
 
     def refresh_limits_cache(self) -> None:
         """Refreshes the limits cache from the backend."""
@@ -27,3 +33,8 @@ class QuotaServiceCacheManager:
         """Refreshes the project name cache from the backend."""
         self.projects_cache = None
         self._load_projects_from_backend()
+
+    def refresh_users_cache(self) -> None:
+        """Refreshes the user name cache from the backend."""
+        self.users_cache = None
+        self._load_users_from_backend()

--- a/tests/backends/mock_backends.py
+++ b/tests/backends/mock_backends.py
@@ -128,6 +128,18 @@ class MockBackend(BaseBackend):
     def delete_project(self, name: str) -> None:
         pass
 
+    def create_user(self, user_name: str, ou_name: Optional[str] = None, email: Optional[str] = None) -> None:
+        pass
+
+    def list_users(self) -> List[Dict]:
+        return []
+
+    def update_user(self, user_name: str, new_name: str) -> None:
+        pass
+
+    def set_user_active(self, user_name: str, active: bool) -> None:
+        pass
+
 
 class IncompleteBackend(BaseBackend):
     """A mock backend that doesn't implement all required methods for BaseBackend interface testing."""

--- a/tests/cli/test_cli_users.py
+++ b/tests/cli/test_cli_users.py
@@ -1,0 +1,35 @@
+import sys
+from unittest.mock import patch
+from llm_accounting.cli.main import main as cli_main
+from llm_accounting import LLMAccounting, SQLiteBackend
+
+
+def run_cli(db_path, args_list):
+    with patch.object(sys, 'argv', ['cli_main'] + args_list):
+        cli_main()
+
+
+def test_cli_user_management(tmp_path, capsys):
+    db_path = str(tmp_path / 'users.sqlite')
+    backend = SQLiteBackend(db_path=db_path)
+    acc = LLMAccounting(backend=backend)
+    with patch('llm_accounting.cli.utils.get_accounting', return_value=acc):
+        run_cli(db_path, ['users', 'add', 'alice', '--ou-name', 'IT', '--email', 'a@example.com'])
+        captured = capsys.readouterr().out
+        assert "User 'alice' added." in captured
+
+        run_cli(db_path, ['users', 'list'])
+        captured = capsys.readouterr().out
+        assert 'alice' in captured
+
+        run_cli(db_path, ['users', 'update', 'alice', 'alice2'])
+        captured = capsys.readouterr().out
+        assert "renamed to 'alice2'" in captured
+
+        run_cli(db_path, ['users', 'deactivate', 'alice2'])
+        captured = capsys.readouterr().out
+        assert "User 'alice2' deactivated." in captured
+
+        run_cli(db_path, ['users', 'list'])
+        captured = capsys.readouterr().out
+        assert 'inactive' in captured

--- a/tests/core/test_user_enforcement.py
+++ b/tests/core/test_user_enforcement.py
@@ -1,0 +1,14 @@
+from llm_accounting import LLMAccounting, SQLiteBackend
+import pytest
+
+
+def test_user_enforcement(tmp_path):
+    db_path = str(tmp_path / 'enf.sqlite')
+    backend = SQLiteBackend(db_path=db_path)
+    acc = LLMAccounting(backend=backend, enforce_user_names=True)
+    acc.quota_service.create_user('alice')
+    with acc:
+        acc.quota_service.refresh_users_cache()
+        acc.track_usage(model='gpt', cost=0.1, prompt_tokens=1, username='alice')
+        with pytest.raises(ValueError):
+            acc.track_usage(model='gpt', cost=0.1, prompt_tokens=1, username='bob')

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 # --- Revision IDs (obtained from previous steps) ---
 REVISION_INITIAL_TABLES = "82f27c891782"
 REVISION_ADD_NOTES_COLUMN = "ba9718840e75"
-REVISION_ADD_INDICES = "f873f865a1ae"
+REVISION_ADD_INDICES = "aa1b2c3d4e5f"
 
 
 # --- Fixtures ---

--- a/tests/utils/concrete_mock_backend.py
+++ b/tests/utils/concrete_mock_backend.py
@@ -84,3 +84,15 @@ class ConcreteTestBackend(BaseBackend):
 
     def delete_project(self, name: str) -> None:
         pass
+
+    def create_user(self, user_name: str, ou_name: Optional[str] = None, email: Optional[str] = None) -> None:
+        pass
+
+    def list_users(self) -> List[Dict]:
+        return []
+
+    def update_user(self, user_name: str, new_name: str) -> None:
+        pass
+
+    def set_user_active(self, user_name: str, active: bool) -> None:
+        pass


### PR DESCRIPTION
## Summary
- add database table and models to manage user names
- enforce allowed user names in the core API
- expose user management on the CLI
- cache allowed users in quota service
- test user enforcement and CLI user commands
- migrate DB schema to include `users` table

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846e1fb30a48333aacba4b8d3f39d67