### PR TITLE
Add user enforcement and dictionary management

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ The following options can be used with any `llm-accounting` command:
 - `--app-name <name>`: Default application name to associate with usage entries. Can be overridden by command-specific `--caller-name`.
 - `--user-name <name>`: Default user name to associate with usage entries. Can be overridden by command-specific `--username`. Defaults to current system user.
 - `--enforce-project-names`: When set, project names supplied to commands must exist in the project dictionary.
+- `--enforce-user-names`: When set, user names supplied to commands must exist in the user dictionary.
 
 ```bash
 # Track a new usage entry (model name is required, timestamp is optional)
@@ -270,6 +271,17 @@ llm-accounting projects add MyProj
 llm-accounting projects list
 llm-accounting projects update MyProj NewName
 llm-accounting projects delete NewName
+```
+
+### User Management
+
+The `users` command manages the list of allowed user names when `--enforce-user-names` is used.
+
+```bash
+llm-accounting users add alice
+llm-accounting users list
+llm-accounting users update alice --new-user-name alice2 --email alice@example.com
+llm-accounting users deactivate alice2
 ```
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A Python package for tracking and analyzing LLM usage across different models an
 - Comprehensive audit logging for all LLM interactions
 - Retrieve remaining quota information after logging usage
 - Optional enforcement of allowed project names with `projects` management commands
+- Optional enforcement of allowed user names with `users` management commands
 
 ## Installation
 

--- a/alembic/versions/aa1b2c3d4e5f_add_users_table.py
+++ b/alembic/versions/aa1b2c3d4e5f_add_users_table.py
@@ -1,6 +1,6 @@
 """add users table
 
-Revision ID: e9b0140ffbfe
+Revision ID: aa1b2c3d4e5f
 Revises: f873f865a1ae
 Create Date: 2025-07-01 00:00:01
 
@@ -9,7 +9,7 @@ from typing import Sequence, Union
 from alembic import op
 import sqlalchemy as sa
 
-revision: str = 'e9b0140ffbfe'
+revision: str = 'aa1b2c3d4e5f'
 down_revision: Union[str, None] = 'f873f865a1ae'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/alembic/versions/e9b0140ffbfe_add_users_table.py
+++ b/alembic/versions/e9b0140ffbfe_add_users_table.py
@@ -1,0 +1,33 @@
+"""add users table
+
+Revision ID: e9b0140ffbfe
+Revises: f873f865a1ae
+Create Date: 2025-07-01 00:00:01
+
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'e9b0140ffbfe'
+down_revision: Union[str, None] = 'f873f865a1ae'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'users',
+        sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column('user_name', sa.String(length=255), nullable=False, unique=True),
+        sa.Column('ou_name', sa.String(length=255), nullable=True),
+        sa.Column('email', sa.String(length=255), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column('last_enabled_at', sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column('last_disabled_at', sa.DateTime(), nullable=True),
+        sa.Column('enabled', sa.Boolean(), nullable=False, server_default=sa.text('1')),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('users')

--- a/src/llm_accounting/backends/base.py
+++ b/src/llm_accounting/backends/base.py
@@ -96,6 +96,18 @@ class UsageStats:
     avg_execution_time: float = 0.0
 
 
+@dataclass
+class UserRecord:
+    user_name: str
+    ou_name: Optional[str] = None
+    email: Optional[str] = None
+    enabled: bool = True
+    id: Optional[int] = None
+    created_at: Optional[datetime] = None
+    last_enabled_at: Optional[datetime] = None
+    last_disabled_at: Optional[datetime] = None
+
+
 class BaseBackend(ABC):
     """Base class for all usage tracking backends"""
 
@@ -256,4 +268,38 @@ class BaseBackend(ABC):
     @abstractmethod
     def delete_project(self, name: str) -> None:
         """Delete a project from the dictionary."""
+        pass
+
+    # --- User Management ---
+
+    @abstractmethod
+    def create_user(
+        self,
+        user_name: str,
+        ou_name: Optional[str] = None,
+        email: Optional[str] = None,
+    ) -> None:
+        """Create a new allowed user."""
+        pass
+
+    @abstractmethod
+    def list_users(self) -> List[UserRecord]:
+        """Return the list of allowed users."""
+        pass
+
+    @abstractmethod
+    def update_user(
+        self,
+        user_name: str,
+        new_user_name: Optional[str] = None,
+        ou_name: Optional[str] = None,
+        email: Optional[str] = None,
+        enabled: Optional[bool] = None,
+    ) -> None:
+        """Update fields of an existing user."""
+        pass
+
+    @abstractmethod
+    def set_user_enabled(self, user_name: str, enabled: bool) -> None:
+        """Enable or disable a user."""
         pass

--- a/src/llm_accounting/backends/mock_backend.py
+++ b/src/llm_accounting/backends/mock_backend.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 import logging
 
-from .base import AuditLogEntry, BaseBackend, UsageEntry, UsageStats
+from .base import AuditLogEntry, BaseBackend, UsageEntry, UsageStats, UserRecord
 from ..models.limits import LimitScope, LimitType, UsageLimitDTO
 
 from .mock_backend_parts.connection_manager import MockConnectionManager
@@ -28,6 +28,7 @@ class MockBackend(BaseBackend):
         self.initialized = False
         self.closed = False
         self.projects: List[str] = []
+        self.users: List[str] = []
 
         self._connection_manager = MockConnectionManager(self)
         self._usage_manager = MockUsageManager(self)
@@ -149,3 +150,26 @@ class MockBackend(BaseBackend):
     def delete_project(self, name: str) -> None:
         if name in self.projects:
             self.projects.remove(name)
+
+    # --- User management ---
+
+    def create_user(self, user_name: str, ou_name: Optional[str] = None, email: Optional[str] = None) -> None:
+        self.users.append(user_name)
+
+    def list_users(self) -> List[UserRecord]:
+        return [UserRecord(user_name=u) for u in self.users]
+
+    def update_user(
+        self,
+        user_name: str,
+        new_user_name: Optional[str] = None,
+        ou_name: Optional[str] = None,
+        email: Optional[str] = None,
+        enabled: Optional[bool] = None,
+    ) -> None:
+        if user_name in self.users and new_user_name:
+            idx = self.users.index(user_name)
+            self.users[idx] = new_user_name
+
+    def set_user_enabled(self, user_name: str, enabled: bool) -> None:
+        pass

--- a/src/llm_accounting/backends/postgresql_backend_parts/user_manager.py
+++ b/src/llm_accounting/backends/postgresql_backend_parts/user_manager.py
@@ -1,0 +1,64 @@
+import logging
+from typing import List
+from datetime import datetime, timezone
+
+class UserManager:
+    def __init__(self, backend_instance):
+        self.backend = backend_instance
+        self.logger = logging.getLogger(__name__)
+
+    def create_user(self, user_name: str, ou_name=None, email=None, enabled=True) -> None:
+        self.backend._ensure_connected()
+        assert self.backend.conn is not None
+        with self.backend.conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO users (user_name, ou_name, email, enabled) VALUES (%s, %s, %s, %s)",
+                (user_name, ou_name, email, enabled),
+            )
+        self.backend.conn.commit()
+
+    def list_users(self) -> List[dict]:
+        self.backend._ensure_connected()
+        assert self.backend.conn is not None
+        with self.backend.conn.cursor() as cur:
+            cur.execute(
+                "SELECT id, user_name, ou_name, email, created_at, last_enabled_at, last_disabled_at, enabled "
+                "FROM users ORDER BY user_name"
+            )
+            columns = [desc[0] for desc in cur.description]
+            return [dict(zip(columns, row)) for row in cur.fetchall()]
+
+    def update_user(self, user_name: str, new_user_name=None, ou_name=None, email=None, enabled=None) -> None:
+        fields = []
+        params = []
+        if new_user_name is not None:
+            fields.append("user_name = %s")
+            params.append(new_user_name)
+        if ou_name is not None:
+            fields.append("ou_name = %s")
+            params.append(ou_name)
+        if email is not None:
+            fields.append("email = %s")
+            params.append(email)
+        ts = datetime.now(timezone.utc)
+        if enabled is not None:
+            fields.append("enabled = %s")
+            params.append(enabled)
+            if enabled:
+                fields.append("last_enabled_at = %s")
+                params.append(ts)
+            else:
+                fields.append("last_disabled_at = %s")
+                params.append(ts)
+        if not fields:
+            return
+        query = "UPDATE users SET " + ", ".join(fields) + " WHERE user_name = %s"
+        params.append(user_name)
+        self.backend._ensure_connected()
+        assert self.backend.conn is not None
+        with self.backend.conn.cursor() as cur:
+            cur.execute(query, params)
+        self.backend.conn.commit()
+
+    def set_user_enabled(self, user_name: str, enabled: bool) -> None:
+        self.update_user(user_name, enabled=enabled)

--- a/src/llm_accounting/backends/sqlite_backend_parts/user_manager.py
+++ b/src/llm_accounting/backends/sqlite_backend_parts/user_manager.py
@@ -1,0 +1,61 @@
+import logging
+from typing import List
+from datetime import datetime, timezone
+
+from sqlalchemy import text
+
+class SQLiteUserManager:
+    def __init__(self, connection_manager):
+        self.connection_manager = connection_manager
+        self.logger = logging.getLogger(__name__)
+
+    def create_user(self, user_name: str, ou_name=None, email=None, enabled=True) -> None:
+        conn = self.connection_manager.get_connection()
+        conn.execute(
+            text(
+                "INSERT INTO users (user_name, ou_name, email, enabled) "
+                "VALUES (:user_name, :ou_name, :email, :enabled)"
+            ),
+            {"user_name": user_name, "ou_name": ou_name, "email": email, "enabled": 1 if enabled else 0},
+        )
+        conn.commit()
+
+    def list_users(self) -> List[dict]:
+        conn = self.connection_manager.get_connection()
+        result = conn.execute(
+            text(
+                "SELECT id, user_name, ou_name, email, created_at, last_enabled_at, last_disabled_at, enabled "
+                "FROM users ORDER BY user_name"
+            )
+        )
+        return [dict(row._mapping) for row in result.fetchall()]
+
+    def update_user(self, user_name: str, new_user_name=None, ou_name=None, email=None, enabled=None) -> None:
+        fields = []
+        params = {"user_name": user_name}
+        if new_user_name is not None:
+            fields.append("user_name = :new_user_name")
+            params["new_user_name"] = new_user_name
+        if ou_name is not None:
+            fields.append("ou_name = :ou_name")
+            params["ou_name"] = ou_name
+        if email is not None:
+            fields.append("email = :email")
+            params["email"] = email
+        if enabled is not None:
+            fields.append("enabled = :enabled")
+            params["enabled"] = 1 if enabled else 0
+            if enabled:
+                fields.append("last_enabled_at = :ts")
+            else:
+                fields.append("last_disabled_at = :ts")
+            params["ts"] = datetime.now(timezone.utc)
+        if not fields:
+            return
+        query = "UPDATE users SET " + ", ".join(fields) + " WHERE user_name = :user_name"
+        conn = self.connection_manager.get_connection()
+        conn.execute(text(query), params)
+        conn.commit()
+
+    def set_user_enabled(self, user_name: str, enabled: bool) -> None:
+        self.update_user(user_name, enabled=enabled)

--- a/src/llm_accounting/cli/commands/users.py
+++ b/src/llm_accounting/cli/commands/users.py
@@ -1,0 +1,31 @@
+from llm_accounting import LLMAccounting
+from ..utils import console
+
+
+def run_user_add(args, accounting: LLMAccounting) -> None:
+    accounting.quota_service.create_user(args.user_name, args.ou_name, args.email)
+    console.print(f"[green]User '{args.user_name}' added.[/green]")
+
+
+def run_user_list(args, accounting: LLMAccounting) -> None:
+    users = accounting.quota_service.list_users()
+    if not users:
+        console.print("[yellow]No users defined.[/yellow]")
+    else:
+        for name in users:
+            console.print(name)
+
+
+def run_user_update(args, accounting: LLMAccounting) -> None:
+    accounting.quota_service.update_user(
+        args.user_name,
+        new_user_name=args.new_user_name,
+        ou_name=args.ou_name,
+        email=args.email,
+    )
+    console.print(f"[green]User '{args.user_name}' updated.[/green]")
+
+
+def run_user_deactivate(args, accounting: LLMAccounting) -> None:
+    accounting.quota_service.set_user_enabled(args.user_name, False)
+    console.print(f"[green]User '{args.user_name}' deactivated.[/green]")

--- a/src/llm_accounting/cli/main.py
+++ b/src/llm_accounting/cli/main.py
@@ -6,7 +6,7 @@ from importlib.metadata import version as get_version
 
 from .parsers import (add_purge_parser, add_select_parser, add_stats_parser,
                       add_tail_parser, add_track_parser, add_limits_parser,
-                      add_log_event_parser, add_projects_parser)
+                      add_log_event_parser, add_projects_parser, add_users_parser)
 from .utils import console
 
 
@@ -90,6 +90,11 @@ def main():
         help="Reject operations using project names not present in the project dictionary.",
     )
     parser.add_argument(
+        "--enforce-user-names",
+        action="store_true",
+        help="Reject operations using user names not present in the user dictionary.",
+    )
+    parser.add_argument(
         "--audit-db-backend",
         type=str,
         choices=["sqlite", "postgresql"],
@@ -116,6 +121,7 @@ def main():
     add_limits_parser(subparsers)
     add_log_event_parser(subparsers) # Added from feat/cli-log-event branch
     add_projects_parser(subparsers)
+    add_users_parser(subparsers)
 
     args = parser.parse_args()
 
@@ -139,6 +145,8 @@ def main():
         )
         if args.enforce_project_names:
             kwargs["enforce_project_names"] = True
+        if args.enforce_user_names:
+            kwargs["enforce_user_names"] = True
         accounting = get_accounting(**kwargs)
         with accounting:
             args.func(args, accounting)

--- a/src/llm_accounting/cli/parsers.py
+++ b/src/llm_accounting/cli/parsers.py
@@ -12,6 +12,12 @@ from llm_accounting.cli.commands.projects import (
     run_project_update,
     run_project_delete,
 )
+from llm_accounting.cli.commands.users import (
+    run_user_add,
+    run_user_list,
+    run_user_update,
+    run_user_deactivate,
+)
 
 
 def add_stats_parser(subparsers):
@@ -262,3 +268,28 @@ def add_projects_parser(subparsers):
     del_p = proj_sub.add_parser("delete", help="Delete a project")
     del_p.add_argument("name", type=str)
     del_p.set_defaults(func=run_project_delete)
+
+
+def add_users_parser(subparsers):
+    parser = subparsers.add_parser("users", help="Manage allowed users")
+    user_sub = parser.add_subparsers(dest="users_command", required=True)
+
+    add_u = user_sub.add_parser("add", help="Add a new user")
+    add_u.add_argument("user_name", type=str)
+    add_u.add_argument("--ou-name", type=str, default=None)
+    add_u.add_argument("--email", type=str, default=None)
+    add_u.set_defaults(func=run_user_add)
+
+    list_u = user_sub.add_parser("list", help="List users")
+    list_u.set_defaults(func=run_user_list)
+
+    upd_u = user_sub.add_parser("update", help="Update a user")
+    upd_u.add_argument("user_name", type=str)
+    upd_u.add_argument("--new-user-name", type=str, default=None)
+    upd_u.add_argument("--ou-name", type=str, default=None)
+    upd_u.add_argument("--email", type=str, default=None)
+    upd_u.set_defaults(func=run_user_update)
+
+    deact_u = user_sub.add_parser("deactivate", help="Deactivate a user")
+    deact_u.add_argument("user_name", type=str)
+    deact_u.set_defaults(func=run_user_deactivate)

--- a/src/llm_accounting/cli/utils.py
+++ b/src/llm_accounting/cli/utils.py
@@ -37,6 +37,7 @@ def get_accounting(
     app_name: Optional[str] = None,
     user_name: Optional[str] = None,
     enforce_project_names: bool = False,
+    enforce_user_names: bool = False,
 ):
     """Get an LLMAccounting instance with the specified backend"""
     if db_backend == "sqlite":
@@ -90,6 +91,7 @@ def get_accounting(
         app_name=app_name,
         user_name=default_user_name,
         enforce_project_names=enforce_project_names,
+        enforce_user_names=enforce_user_names,
     )
     return acc
 

--- a/src/llm_accounting/models/__init__.py
+++ b/src/llm_accounting/models/__init__.py
@@ -3,5 +3,6 @@ from .audit import AuditLogEntryModel
 from .base import Base
 from .limits import UsageLimit
 from .project import Project
+from .user import User
 
-__all__ = ["Base", "AccountingEntry", "AuditLogEntryModel", "UsageLimit", "Project"]
+__all__ = ["Base", "AccountingEntry", "AuditLogEntryModel", "UsageLimit", "Project", "User"]

--- a/src/llm_accounting/models/user.py
+++ b/src/llm_accounting/models/user.py
@@ -1,0 +1,23 @@
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import Column, DateTime, Integer, String, Boolean
+
+from llm_accounting.models.base import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+    __table_args__ = {"extend_existing": True}
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_name = Column(String(255), nullable=False, unique=True)
+    ou_name = Column(String(255), nullable=True)
+    email = Column(String(255), nullable=True)
+    created_at = Column(DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
+    last_enabled_at = Column(DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
+    last_disabled_at = Column(DateTime, nullable=True)
+    enabled = Column(Boolean, nullable=False, default=True)
+
+    def __repr__(self) -> str:
+        return f"<User(id={self.id}, user_name='{self.user_name}', enabled={self.enabled})>"

--- a/src/llm_accounting/services/quota_service.py
+++ b/src/llm_accounting/services/quota_service.py
@@ -33,6 +33,10 @@ class QuotaService:
         """Refreshes the projects cache from the backend."""
         self.cache_manager.refresh_projects_cache()
 
+    def refresh_users_cache(self) -> None:
+        """Refreshes the users cache from the backend."""
+        self.cache_manager.refresh_users_cache()
+
     def insert_limit(self, limit: UsageLimitDTO) -> None:
         """Inserts a new usage limit and refreshes the cache."""
         self.backend.insert_usage_limit(limit)
@@ -61,6 +65,32 @@ class QuotaService:
     def delete_project(self, name: str) -> None:
         self.backend.delete_project(name)
         self.refresh_projects_cache()
+
+    # --- User management ---
+
+    def create_user(self, user_name: str, ou_name: Optional[str] = None, email: Optional[str] = None) -> None:
+        self.backend.create_user(user_name, ou_name, email)
+        self.refresh_users_cache()
+
+    def list_users(self) -> List[str]:
+        if self.cache_manager.users_cache is None:
+            self.cache_manager._load_users_from_backend()
+        return self.cache_manager.users_cache
+
+    def update_user(
+        self,
+        user_name: str,
+        new_user_name: Optional[str] = None,
+        ou_name: Optional[str] = None,
+        email: Optional[str] = None,
+        enabled: Optional[bool] = None,
+    ) -> None:
+        self.backend.update_user(user_name, new_user_name, ou_name, email, enabled)
+        self.refresh_users_cache()
+
+    def set_user_enabled(self, user_name: str, enabled: bool) -> None:
+        self.backend.set_user_enabled(user_name, enabled)
+        self.refresh_users_cache()
 
     def check_quota(
         self,

--- a/src/llm_accounting/services/quota_service_parts/_cache_manager.py
+++ b/src/llm_accounting/services/quota_service_parts/_cache_manager.py
@@ -7,8 +7,10 @@ class QuotaServiceCacheManager:
         self.backend = backend
         self.limits_cache: Optional[List[UsageLimitDTO]] = None
         self.projects_cache: Optional[List[str]] = None
+        self.users_cache: Optional[List[str]] = None
         self._load_limits_from_backend()
         self._load_projects_from_backend()
+        self._load_users_from_backend()
 
     def _load_limits_from_backend(self) -> None:
         """Loads all usage limits from the backend into the cache."""
@@ -17,6 +19,16 @@ class QuotaServiceCacheManager:
     def _load_projects_from_backend(self) -> None:
         """Loads allowed project names from the backend."""
         self.projects_cache = self.backend.list_projects()
+
+    def _load_users_from_backend(self) -> None:
+        """Loads allowed user names from the backend."""
+        if hasattr(self.backend, "list_users"):
+            try:
+                self.users_cache = [u.user_name for u in self.backend.list_users()]
+            except TypeError:
+                self.users_cache = []
+        else:
+            self.users_cache = []
 
     def refresh_limits_cache(self) -> None:
         """Refreshes the limits cache from the backend."""
@@ -27,3 +39,8 @@ class QuotaServiceCacheManager:
         """Refreshes the project name cache from the backend."""
         self.projects_cache = None
         self._load_projects_from_backend()
+
+    def refresh_users_cache(self) -> None:
+        """Refreshes the user name cache from the backend."""
+        self.users_cache = None
+        self._load_users_from_backend()

--- a/tests/backends/mock_backends.py
+++ b/tests/backends/mock_backends.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
+from llm_accounting.backends.base import UserRecord
 from typing_extensions import override
 
 
@@ -126,6 +127,25 @@ class MockBackend(BaseBackend):
         pass
 
     def delete_project(self, name: str) -> None:
+        pass
+
+    def create_user(self, user_name: str, ou_name: Optional[str] = None, email: Optional[str] = None) -> None:
+        pass
+
+    def list_users(self) -> List[UserRecord]:
+        return []
+
+    def update_user(
+        self,
+        user_name: str,
+        new_user_name: Optional[str] = None,
+        ou_name: Optional[str] = None,
+        email: Optional[str] = None,
+        enabled: Optional[bool] = None,
+    ) -> None:
+        pass
+
+    def set_user_enabled(self, user_name: str, enabled: bool) -> None:
         pass
 
 

--- a/tests/cli/test_cli_users.py
+++ b/tests/cli/test_cli_users.py
@@ -1,0 +1,35 @@
+import sys
+from unittest.mock import patch
+from llm_accounting.cli.main import main as cli_main
+from llm_accounting import LLMAccounting, SQLiteBackend
+
+
+def run_cli(args_list):
+    with patch.object(sys, 'argv', ['cli_main'] + args_list):
+        cli_main()
+
+
+def test_cli_user_management(tmp_path, capsys):
+    db_path = str(tmp_path / 'u.sqlite')
+    backend = SQLiteBackend(db_path=db_path)
+    acc = LLMAccounting(backend=backend)
+    with patch('llm_accounting.cli.utils.get_accounting', return_value=acc):
+        run_cli(['users', 'add', 'alice'])
+        captured = capsys.readouterr().out
+        assert "User 'alice' added." in captured
+
+        run_cli(['users', 'list'])
+        captured = capsys.readouterr().out
+        assert 'alice' in captured
+
+        run_cli(['users', 'update', 'alice', '--new-user-name', 'bob'])
+        captured = capsys.readouterr().out
+        assert 'updated' in captured
+
+        run_cli(['users', 'deactivate', 'bob'])
+        captured = capsys.readouterr().out
+        assert 'deactivated' in captured
+
+        run_cli(['users', 'list'])
+        captured = capsys.readouterr().out
+        assert 'bob' in captured

--- a/tests/core/test_user_cache.py
+++ b/tests/core/test_user_cache.py
@@ -1,0 +1,14 @@
+from llm_accounting import LLMAccounting, SQLiteBackend
+
+
+def test_user_cache_refresh(tmp_path):
+    db = str(tmp_path / 'cache.sqlite')
+    backend = SQLiteBackend(db_path=db)
+    acc = LLMAccounting(backend=backend)
+    with acc:
+        acc.quota_service.create_user('alice')
+        users = acc.quota_service.list_users()
+        assert users == ['alice']
+        acc.quota_service.create_user('bob')
+        users2 = acc.quota_service.list_users()
+        assert set(users2) == {'alice', 'bob'}

--- a/tests/core/test_user_enforcement.py
+++ b/tests/core/test_user_enforcement.py
@@ -1,0 +1,14 @@
+import pytest
+from llm_accounting import LLMAccounting, SQLiteBackend
+
+
+def test_user_enforcement(tmp_path):
+    db_path = str(tmp_path / 'enf.sqlite')
+    backend = SQLiteBackend(db_path=db_path)
+    acc = LLMAccounting(backend=backend, enforce_user_names=True)
+    acc.quota_service.create_user('john')
+    with acc:
+        acc.quota_service.refresh_users_cache()
+        acc.track_usage(model='gpt', cost=0.1, prompt_tokens=1, username='john')
+        with pytest.raises(ValueError):
+            acc.track_usage(model='gpt', cost=0.1, prompt_tokens=1, username='bad')

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 # --- Revision IDs (obtained from previous steps) ---
 REVISION_INITIAL_TABLES = "82f27c891782"
 REVISION_ADD_NOTES_COLUMN = "ba9718840e75"
-REVISION_ADD_INDICES = "f873f865a1ae"
+REVISION_ADD_INDICES = "e9b0140ffbfe"
 
 
 # --- Fixtures ---

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 # --- Revision IDs (obtained from previous steps) ---
 REVISION_INITIAL_TABLES = "82f27c891782"
 REVISION_ADD_NOTES_COLUMN = "ba9718840e75"
-REVISION_ADD_INDICES = "e9b0140ffbfe"
+REVISION_ADD_INDICES = "aa1b2c3d4e5f"
 
 
 # --- Fixtures ---

--- a/tests/utils/concrete_mock_backend.py
+++ b/tests/utils/concrete_mock_backend.py
@@ -1,7 +1,13 @@
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
-from llm_accounting.backends.base import BaseBackend, AuditLogEntry, UsageEntry, UsageStats
+from llm_accounting.backends.base import (
+    BaseBackend,
+    AuditLogEntry,
+    UsageEntry,
+    UsageStats,
+    UserRecord,
+)
 from llm_accounting.models.limits import LimitScope, LimitType, UsageLimitDTO
 
 
@@ -83,4 +89,24 @@ class ConcreteTestBackend(BaseBackend):
         pass
 
     def delete_project(self, name: str) -> None:
+        pass
+
+    # user management
+    def create_user(self, user_name: str, ou_name: Optional[str] = None, email: Optional[str] = None) -> None:
+        pass
+
+    def list_users(self) -> List[UserRecord]:
+        return []
+
+    def update_user(
+        self,
+        user_name: str,
+        new_user_name: Optional[str] = None,
+        ou_name: Optional[str] = None,
+        email: Optional[str] = None,
+        enabled: Optional[bool] = None,
+    ) -> None:
+        pass
+
+    def set_user_enabled(self, user_name: str, enabled: bool) -> None:
         pass


### PR DESCRIPTION
## Summary
- introduce User model and database migration
- add user management API and CLI commands
- enforce allowed usernames when enabled
- cache allowed usernames in QuotaService
- update tests for user enforcement and CLI user management

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847057977b483338f184d18189b85cb