### PR TITLE
Add database workload separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,20 +641,20 @@ accounting_postgresql_direct.close()
 
 ### Custom Backend Implementation
 
-The `llm-accounting` library is designed with a pluggable backend system, allowing you to integrate with any database or data storage solution by implementing the `BaseBackend` abstract class. This is particularly useful for integrating with existing infrastructure or custom data handling requirements.
+The `llm-accounting` library is designed with a pluggable backend system, allowing you to integrate with any database or data storage solution by implementing the `TransactionalBackend` and `AuditBackend` abstract classes. This separation lets you optimize transactional workloads independently from audit logging while remaining compatible with existing `BaseBackend` implementations.
 
 Here's how you can implement your own custom backend, using the `MockBackend` as a simplified example:
 
-1. **Define your Backend Class**: Create a new class that inherits from `llm_accounting.backends.base.BaseBackend`. You will need to implement all abstract methods defined in `BaseBackend`.
+1. **Define your Backend Class**: Create a new class that inherits from `llm_accounting.backends.base.TransactionalBackend` (and optionally `AuditBackend`). You will need to implement all abstract methods defined in these base classes.
 
     ```python
     # my_custom_backend.py
     from datetime import datetime
     from typing import Dict, List, Tuple, Any, Optional
 
-    from llm_accounting.backends.base import BaseBackend, UsageEntry, UsageStats
+    from llm_accounting.backends.base import TransactionalBackend, UsageEntry, UsageStats
 
-    class MyCustomBackend(BaseBackend):
+    class MyCustomBackend(TransactionalBackend):
         def __init__(self):
             self.usage_storage = [] # Example: a list to store UsageEntry objects
             # Add storage for limits if needed

--- a/src/llm_accounting/__init__.py
+++ b/src/llm_accounting/__init__.py
@@ -15,7 +15,13 @@ from datetime import datetime
 from typing import Dict, List, Optional, Tuple
 
 from .audit_log import AuditLogger
-from .backends.base import BaseBackend, UsageEntry, UsageStats
+from .backends.base import (
+    BaseBackend,
+    TransactionalBackend,
+    AuditBackend,
+    UsageEntry,
+    UsageStats,
+)
 from .backends.mock_backend import MockBackend
 from .backends.sqlite import SQLiteBackend
 from .models.limits import LimitScope, LimitType, TimeInterval, UsageLimitDTO
@@ -31,6 +37,8 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "LLMAccounting",
     "BaseBackend",
+    "TransactionalBackend",
+    "AuditBackend",
     "UsageEntry",
     "UsageStats",
     "SQLiteBackend",
@@ -48,11 +56,11 @@ class LLMAccounting:
 
     def __init__(
         self,
-        backend: Optional[BaseBackend] = None,
+        backend: Optional[TransactionalBackend] = None,
         project_name: Optional[str] = None,
         app_name: Optional[str] = None,
         user_name: Optional[str] = None,
-        audit_backend: Optional[BaseBackend] = None,
+        audit_backend: Optional[AuditBackend] = None,
         enforce_project_names: bool = False,
         enforce_user_names: bool = False,
     ):

--- a/src/llm_accounting/audit_log.py
+++ b/src/llm_accounting/audit_log.py
@@ -1,7 +1,7 @@
 from typing import Optional, List # Added List
 from datetime import datetime, timezone
 
-from .backends.base import BaseBackend, AuditLogEntry # Added BaseBackend, AuditLogEntry
+from .backends.base import AuditBackend, AuditLogEntry
 
 
 # initialize_audit_db_schema function removed
@@ -9,14 +9,14 @@ from .backends.base import BaseBackend, AuditLogEntry # Added BaseBackend, Audit
 
 class AuditLogger:
     """
-    A class for logging audit trail entries, delegating to a BaseBackend.
+    A class for logging audit trail entries, delegating to an AuditBackend.
     """
-    def __init__(self, backend: BaseBackend):
+    def __init__(self, backend: AuditBackend):
         """
         Initializes the AuditLogger with a backend.
 
         Args:
-            backend: An instance of a class that implements BaseBackend.
+            backend: An instance of a class that implements AuditBackend.
         """
         self.backend = backend
         # self.db_path and self.conn removed

--- a/src/llm_accounting/services/quota_service.py
+++ b/src/llm_accounting/services/quota_service.py
@@ -2,7 +2,7 @@ import logging
 from typing import Optional, Tuple, Dict, List
 from datetime import datetime, timezone # Import datetime and timezone
 
-from ..backends.base import BaseBackend
+from ..backends.base import TransactionalBackend
 from ..models.limits import LimitScope, UsageLimitDTO
 
 from .quota_service_parts._cache_manager import QuotaServiceCacheManager
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 class QuotaService:
-    def __init__(self, backend: BaseBackend):
+    def __init__(self, backend: TransactionalBackend):
         self.backend = backend
         self.cache_manager = QuotaServiceCacheManager(backend)
         self.limit_evaluator = QuotaServiceLimitEvaluator(backend)

--- a/src/llm_accounting/services/quota_service_parts/_cache_manager.py
+++ b/src/llm_accounting/services/quota_service_parts/_cache_manager.py
@@ -1,9 +1,9 @@
 from typing import Optional, List
-from ...backends.base import BaseBackend
+from ...backends.base import TransactionalBackend
 from ...models.limits import UsageLimitDTO
 
 class QuotaServiceCacheManager:
-    def __init__(self, backend: BaseBackend):
+    def __init__(self, backend: TransactionalBackend):
         self.backend = backend
         self.limits_cache: Optional[List[UsageLimitDTO]] = None
         self.projects_cache: Optional[List[str]] = None

--- a/src/llm_accounting/services/quota_service_parts/_limit_evaluator.py
+++ b/src/llm_accounting/services/quota_service_parts/_limit_evaluator.py
@@ -2,11 +2,11 @@ import logging # Added logging import
 from datetime import datetime, timedelta, timezone
 from typing import Optional, Tuple, List
 
-from ...backends.base import BaseBackend
+from ...backends.base import TransactionalBackend
 from ...models.limits import LimitType, TimeInterval, UsageLimitDTO, LimitScope
 
 class QuotaServiceLimitEvaluator:
-    def __init__(self, backend: BaseBackend):
+    def __init__(self, backend: TransactionalBackend):
         self.backend = backend
 
     def _prepare_usage_query_params(self, limit: UsageLimitDTO, limit_scope_enum: LimitScope) -> Tuple[Optional[str], Optional[str], Optional[str], Optional[str], Optional[bool]]:

--- a/tests/accounting/test_multi_dimensional_quota.py
+++ b/tests/accounting/test_multi_dimensional_quota.py
@@ -5,7 +5,7 @@ from freezegun import freeze_time
 from llm_accounting import LLMAccounting
 from llm_accounting.backends.sqlite import SQLiteBackend
 from llm_accounting.models.limits import LimitScope, LimitType, TimeInterval, UsageLimitDTO
-from llm_accounting.backends.base import BaseBackend
+from llm_accounting.backends.base import TransactionalBackend
 from llm_accounting.services.quota_service import QuotaService
 
 
@@ -178,7 +178,7 @@ def test_model_and_project_limits_first_triggered(accounting_instance: LLMAccoun
 @freeze_time("2024-01-01 00:00:40", tz_offset=0)
 def test_denial_cache_ttl_behavior():
     from unittest.mock import MagicMock
-    mock_backend = MagicMock(spec=BaseBackend)
+    mock_backend = MagicMock(spec=TransactionalBackend)
 
     limit = UsageLimitDTO(
         scope=LimitScope.GLOBAL.value,

--- a/tests/api_compatibility/test_audit_logger_api.py
+++ b/tests/api_compatibility/test_audit_logger_api.py
@@ -2,12 +2,12 @@ import unittest
 from unittest.mock import MagicMock, Mock
 
 from llm_accounting.audit_log import AuditLogger
-from llm_accounting.backends.base import BaseBackend, AuditLogEntry
+from llm_accounting.backends.base import AuditBackend, AuditLogEntry
 
 
 class TestAuditLoggerAPI(unittest.TestCase):
     def setUp(self):
-        self.mock_backend = Mock(spec=BaseBackend)
+        self.mock_backend = Mock(spec=AuditBackend)
         self.logger = AuditLogger(backend=self.mock_backend)
 
     def test_audit_logger_api_methods_exist(self) -> None:

--- a/tests/core/test_quota_service.py
+++ b/tests/core/test_quota_service.py
@@ -6,13 +6,13 @@ from typing import Optional, Dict, Tuple
 from llm_accounting.models.limits import (LimitScope, LimitType, TimeInterval,
                                           UsageLimitDTO)
 from llm_accounting.services.quota_service import QuotaService
-from llm_accounting.backends.base import BaseBackend
+from llm_accounting.backends.base import TransactionalBackend
 from llm_accounting import LLMAccounting # Added import
 
 @pytest.fixture
 def mock_backend() -> MagicMock:
-    """Provides a MagicMock instance for BaseBackend."""
-    backend = MagicMock(spec=BaseBackend)
+    """Provides a MagicMock instance for TransactionalBackend."""
+    backend = MagicMock(spec=TransactionalBackend)
     backend.get_usage_limits.return_value = []
     return backend
 

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, call # Added Mock and call
 from typing import List # Added List
 
 from llm_accounting.audit_log import AuditLogger
-from llm_accounting.backends.base import BaseBackend, AuditLogEntry
+from llm_accounting.backends.base import AuditBackend, AuditLogEntry
 
 # EXPECTED_COLUMNS removed
 # Old fixtures (memory_logger, temp_db_path, file_logger) removed
@@ -14,8 +14,8 @@ from llm_accounting.backends.base import BaseBackend, AuditLogEntry
 
 @pytest.fixture
 def mock_backend() -> Mock:
-    """Provides a mock BaseBackend instance."""
-    return Mock(spec=BaseBackend)
+    """Provides a mock AuditBackend instance."""
+    return Mock(spec=AuditBackend)
 
 @pytest.fixture
 def audit_logger_with_mock_backend(mock_backend: Mock) -> AuditLogger:

--- a/tests/test_dual_backend.py
+++ b/tests/test_dual_backend.py
@@ -2,12 +2,12 @@ import pytest
 from unittest.mock import Mock
 
 from llm_accounting import LLMAccounting
-from llm_accounting.backends.base import BaseBackend
+from llm_accounting.backends.base import TransactionalBackend, AuditBackend
 
 
 def test_separate_audit_backend_usage():
-    usage_backend = Mock(spec=BaseBackend)
-    audit_backend = Mock(spec=BaseBackend)
+    usage_backend = Mock(spec=TransactionalBackend)
+    audit_backend = Mock(spec=AuditBackend)
 
     acc = LLMAccounting(backend=usage_backend, audit_backend=audit_backend)
 


### PR DESCRIPTION
## Summary
- introduce `TransactionalBackend` and `AuditBackend` abstractions
- update core classes and services to use new abstractions
- refactor tests to mock new backend types
- document backend separation in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847f6e2e34c8333a13dcd15fbe0c081