### PR TITLE
Fix failing tests and implement missing APIs

### DIFF
--- a/src/llm_accounting/__init__.py
+++ b/src/llm_accounting/__init__.py
@@ -152,29 +152,29 @@ class LLMAccounting:
         )
         self.backend.insert_usage(entry)
 
-    # TODO: Vulture - Dead code? Verify if used externally or planned for future use before removing.
-    # def track_usage_with_remaining_limits(
-    #     self,
-    #     model: str,
-    #     prompt_tokens: Optional[int] = None,
-    #     completion_tokens: Optional[int] = None,
-    #     total_tokens: Optional[int] = None,
-    #     local_prompt_tokens: Optional[int] = None,
-    #     local_completion_tokens: Optional[int] = None,
-    #     local_total_tokens: Optional[int] = None,
-    #     cost: float = 0.0,
-    #     execution_time: float = 0.0,
-    #     timestamp: Optional[datetime] = None,
-    #     caller_name: Optional[str] = None,
-    #     username: Optional[str] = None,
-    #     cached_tokens: int = 0,
-    #     reasoning_tokens: int = 0,
-    #     project: Optional[str] = None,
-    #     session: Optional[str] = None,
-    # ) -> List[Tuple[UsageLimitDTO, float]]:
-    #     """Track usage and return remaining quota for all applicable limits."""
-    #     self._ensure_valid_project(project if project is not None else self.project_name)
+    def track_usage_with_remaining_limits(
+        self,
+        model: str,
+        prompt_tokens: Optional[int] = None,
+        completion_tokens: Optional[int] = None,
+        total_tokens: Optional[int] = None,
+        local_prompt_tokens: Optional[int] = None,
+        local_completion_tokens: Optional[int] = None,
+        local_total_tokens: Optional[int] = None,
+        cost: float = 0.0,
+        execution_time: float = 0.0,
+        timestamp: Optional[datetime] = None,
+        caller_name: Optional[str] = None,
+        username: Optional[str] = None,
+        cached_tokens: int = 0,
+        reasoning_tokens: int = 0,
+        project: Optional[str] = None,
+        session: Optional[str] = None,
+    ) -> List[Tuple["UsageLimitDTO", float]]:
+        """Track usage and return remaining quota for all applicable limits."""
+        self._ensure_valid_project(project if project is not None else self.project_name)
         self._ensure_valid_user(username if username is not None else self.user_name)
+
         self.track_usage(
             model=model,
             prompt_tokens=prompt_tokens,
@@ -194,7 +194,6 @@ class LLMAccounting:
             session=session,
         )
 
-        # Calculate total tokens if not provided
         if total_tokens is None:
             if prompt_tokens is not None and completion_tokens is not None:
                 total_tokens = prompt_tokens + completion_tokens
@@ -212,6 +211,7 @@ class LLMAccounting:
             completion_tokens=completion_tokens or local_completion_tokens or 0,
             cost=cost,
         )
+
 
     def get_period_stats(self, start: datetime, end: datetime) -> UsageStats:
         """Get aggregated statistics for a time period"""
@@ -318,12 +318,8 @@ class LLMAccounting:
         self.backend._ensure_connected()
         self.quota_service.delete_limit(limit_id)
 
-    # TODO: Vulture - Dead code? Verify if used externally or planned for future use before removing.
-    # def get_db_path(self) -> Optional[str]:
-    #     """
-    #     Returns the database path if the backend is a SQLiteBackend.
-    #     Otherwise, returns None.
-    #     """
-    #     if isinstance(self.backend, SQLiteBackend):
-    #         return self.backend.db_path
-    #     return None
+    def get_db_path(self) -> Optional[str]:
+        """Return the database path if using a SQLite backend."""
+        if isinstance(self.backend, SQLiteBackend):
+            return self.backend.db_path
+        return None

--- a/src/llm_accounting/audit_log.py
+++ b/src/llm_accounting/audit_log.py
@@ -56,6 +56,73 @@ class AuditLogger:
         )
         self.backend.log_audit_event(audit_entry)
 
+    def log_prompt(
+        self,
+        app_name: str,
+        user_name: str,
+        model: str,
+        prompt_text: str,
+        project: Optional[str] = None,
+        timestamp: Optional[datetime] = None,
+        session: Optional[str] = None,
+    ) -> None:
+        """Log a prompt event."""
+        self.log_event(
+            app_name=app_name,
+            user_name=user_name,
+            model=model,
+            log_type="prompt",
+            prompt_text=prompt_text,
+            project=project,
+            timestamp=timestamp,
+            session=session,
+        )
+
+    def log_response(
+        self,
+        app_name: str,
+        user_name: str,
+        model: str,
+        response_text: str,
+        remote_completion_id: Optional[str] = None,
+        project: Optional[str] = None,
+        timestamp: Optional[datetime] = None,
+        session: Optional[str] = None,
+    ) -> None:
+        """Log a response event."""
+        self.log_event(
+            app_name=app_name,
+            user_name=user_name,
+            model=model,
+            log_type="response",
+            response_text=response_text,
+            remote_completion_id=remote_completion_id,
+            project=project,
+            timestamp=timestamp,
+            session=session,
+        )
+
+    def get_entries(
+        self,
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
+        app_name: Optional[str] = None,
+        user_name: Optional[str] = None,
+        project: Optional[str] = None,
+        log_type: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> List[AuditLogEntry]:
+        """Retrieve audit log entries from the backend."""
+        return self.backend.get_audit_log_entries(
+            start_date=start_date,
+            end_date=end_date,
+            app_name=app_name,
+            user_name=user_name,
+            project=project,
+            log_type=log_type,
+            limit=limit,
+        )
+
     # TODO: Vulture - Dead code? Verify if used externally or planned for future use before removing.
     # def log_prompt(
     #     self,

--- a/src/llm_accounting/backends/base.py
+++ b/src/llm_accounting/backends/base.py
@@ -109,9 +109,8 @@ class UserRecord:
     enabled: bool = True
     id: Optional[int] = None
     created_at: Optional[datetime] = None
-    # TODO: Vulture - verify and remove if truly dead code. These fields might be useful for future auditing.
-    # last_enabled_at: Optional[datetime] = None
-    # last_disabled_at: Optional[datetime] = None
+    last_enabled_at: Optional[datetime] = None
+    last_disabled_at: Optional[datetime] = None
 
 
 class TransactionalBackend(ABC):

--- a/src/llm_accounting/cli/commands/select.py
+++ b/src/llm_accounting/cli/commands/select.py
@@ -43,23 +43,21 @@ def _display_results(results: List[Dict[str, Any]], format_type: str) -> None:
         console.print("[yellow]No results found[/yellow]")
         return
 
+    headers = list(results[0].keys())
+
     if format_type == "table":
         table = Table(title="Query Results")
-        headers = list(results[0].keys()) # Ensure consistent order
-
-        if format_type == "table":
-            table = Table(title="Query Results")
-            for col_name in headers:
-                table.add_column(col_name, style="cyan")
-            for row_dict in results:
-                row_values = [str(row_dict.get(h, "N/A")) for h in headers]
-                table.add_row(*row_values)
-            console.print(table)
-        elif format_type == "csv":
-            console.print(",".join(headers)) # Use console.print for consistency, though print works
-            for row_dict in results:
-                row_values = [str(row_dict.get(h, "")) for h in headers] # Use empty string for missing CSV values
-                console.print(",".join(row_values)) # Use console.print
+        for col_name in headers:
+            table.add_column(col_name, style="cyan")
+        for row_dict in results:
+            row_values = [str(row_dict.get(h, "N/A")) for h in headers]
+            table.add_row(*row_values)
+        console.print(table)
+    elif format_type == "csv":
+        print(",".join(headers))
+        for row_dict in results:
+            row_values = ["" if row_dict.get(h) is None else str(row_dict.get(h, "")) for h in headers]
+            print(",".join(row_values))
 
 # --- END NEW HELPER FUNCTIONS ---
 

--- a/src/llm_accounting/cli/utils.py
+++ b/src/llm_accounting/cli/utils.py
@@ -7,6 +7,7 @@ from llm_accounting import LLMAccounting
 
 from ..backends.sqlite import SQLiteBackend
 from ..backends.postgresql import PostgreSQLBackend
+from ..backends.base import BaseBackend
 
 console = Console()
 

--- a/src/llm_accounting/db_migrations.py
+++ b/src/llm_accounting/db_migrations.py
@@ -4,7 +4,7 @@ from alembic import command as alembic_command
 from sqlalchemy.engine.url import make_url
 from sqlalchemy import text, Connection  # Added Connection
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple
 
 from alembic.script import ScriptDirectory
 # EnvironmentContext might still be used by other parts of Alembic or if some logic path needs it,

--- a/src/llm_accounting/models/user.py
+++ b/src/llm_accounting/models/user.py
@@ -14,9 +14,9 @@ class User(Base):
     ou_name = Column(String(255), nullable=True)
     email = Column(String(255), nullable=True)
     created_at = Column(DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
-    # TODO: Vulture - verify and remove if truly dead code. These fields might be useful for future auditing.
-    # last_enabled_at = Column(DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
-    # last_disabled_at = Column(DateTime, nullable=True)
+    # These fields are used by some migrations and tests; keep them for now.
+    last_enabled_at = Column(DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
+    last_disabled_at = Column(DateTime, nullable=True)
     enabled = Column(Boolean, nullable=False, default=True)
 
     def __repr__(self) -> str:


### PR DESCRIPTION
## Summary
- fix typo in db migrations typing imports
- implement missing AuditLogger API methods
- restore `track_usage_with_remaining_limits` and add `get_db_path`
- add missing user fields and user record attributes
- fix select command CSV output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dfcfa3480833395b2bbc3a6c41aa3